### PR TITLE
xcode/swift related gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+### https://github.com/github/gitignore/blob/master/Swift.gitignore
+
+# ====================
+# macOS
+# ====================
+.DS_Store
+
+
+# ====================
+# Obj-c/Swift
+# ====================
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+## Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+.build/
+
+
+# ====================  
+# XCode
+# ====================
+
+## Build Generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+
+## Cocoapods
+# consider adding
+# Pods/


### PR DESCRIPTION
copypasta'ed most related things from the [github gitignore repo](https://github.com/github/gitignore/blob/master/Swift.gitignore)
probably should be pulled asap to save headaches
