### PR TITLE
Moves dining item to top of list when user favorites it

### DIFF
--- a/berkeleyMobileiOS/Classes/Base/Components/ToggleButton.swift
+++ b/berkeleyMobileiOS/Classes/Base/Components/ToggleButton.swift
@@ -2,8 +2,7 @@
 import UIKit
 
 
-protocol ToggleButtonDelegate
-{
+protocol ToggleButtonDelegate {
     func buttonDidToggle(_ button: ToggleButton)
 }
 
@@ -22,25 +21,20 @@ protocol ToggleButtonDelegate
  *  the `isSelected` state is not guaranteed to be flipped before the the action is called.
  *  Any action that requires the updated the state should implment 
  */
-class ToggleButton: UIButton
-{    
-    override func awakeFromNib()
-    {
+class ToggleButton: UIButton {
+    override func awakeFromNib() {
         self.addTarget(self, action: #selector(toggled), for: .touchUpInside)
     }
     
-    func toggled()
-    {
+    func toggled() {
         self.isSelected = !self.isSelected
         
         var next = self.next
-        while next.notNil && (next as? ToggleButtonDelegate).isNil  
-        {
+        while next.notNil && (next as? ToggleButtonDelegate).isNil {
             next = next?.next
         }
         
-        if let delegate = next as? ToggleButtonDelegate
-        {
+        if let delegate = next as? ToggleButtonDelegate {
             delegate.buttonDidToggle(self)
         }
     }

--- a/berkeleyMobileiOS/Classes/Dining/DiningMenu/DiningItemCell.swift
+++ b/berkeleyMobileiOS/Classes/Dining/DiningMenu/DiningItemCell.swift
@@ -5,6 +5,9 @@ import Firebase
 fileprivate let kCellPadding: CGFloat = 12.0
 fileprivate let kContentHeight: CGFloat = 44.0
 
+protocol DiningItemCellDelegate {
+    func didFavoriteItem()
+}
 
 /**
  * TableViewCell to represent a single DiningMenu item. 
@@ -13,6 +16,8 @@ class DiningItemCell: UITableViewCell, RequiresData, ToggleButtonDelegate
 {
     // Data
     private var item: DiningItem!
+    
+    var delegate: DiningItemCellDelegate?
 
     // UI
     @IBOutlet private weak var nameLabel: UILabel!
@@ -32,16 +37,13 @@ class DiningItemCell: UITableViewCell, RequiresData, ToggleButtonDelegate
     // ========================================
     typealias DataType = DiningItem
     
-    /// Receive the DiningItem to represent, whehter it's already favorited, and an optional callback. 
-    func setData(_ item: DataType)
-    {
+    /// Receive the DiningItem to represent, whether it's already favorited, and an optional callback.
+    func setData(_ item: DataType) {
         self.item = item
         
-        var str = item.name
+        let str = item.name
         
-        if str.characters.contains("$"){
-            
-            
+        if str.contains("$") {
             let start = str.index(str.startIndex, offsetBy: 0)
             let end = str.index(str.endIndex, offsetBy: -5)
             let range = start..<end
@@ -55,8 +57,7 @@ class DiningItemCell: UITableViewCell, RequiresData, ToggleButtonDelegate
             let nameString = str[range]
         
             let costString = str[range2]
-        
-        
+            
             nameLabel.text = nameString
         
             costLabel.text = costString.trimmingCharacters(in: .whitespaces)
@@ -69,8 +70,6 @@ class DiningItemCell: UITableViewCell, RequiresData, ToggleButtonDelegate
         favoriteButton.isSelected = item.isFavorited
         
         let restrictions = item.restrictions
-        
-        let screenWidth = UIScreen.main.bounds.width
         
         // word wrapping dependent on number of images
         switch restrictions.count {
@@ -99,7 +98,7 @@ class DiningItemCell: UITableViewCell, RequiresData, ToggleButtonDelegate
 
         // add diet restrictions to imageviews
         let dietImages: [UIImageView] = [dietImageView1, dietImageView2, dietImageView3, dietImageView4, dietImageView5, dietImageView5, dietImageView6]
-        if (restrictions.count > 0) {
+        if restrictions.count > 0 {
             
             for index in 0...6 {
                 let dietImageView = dietImages[index]
@@ -147,14 +146,9 @@ class DiningItemCell: UITableViewCell, RequiresData, ToggleButtonDelegate
                 } else {
                     dietImageView.image = nil
                 }
-                
             }
         }
-        
-        
     }
-    
-    
     
     // ========================================
     // MARK: - ToggleButtonDelegate
@@ -167,11 +161,10 @@ class DiningItemCell: UITableViewCell, RequiresData, ToggleButtonDelegate
      *  but because that requires an extra layer of delegation/callback,
      *  opted to include the Store write action here.
      */
-    func buttonDidToggle(_ button: ToggleButton)
-    {
+    func buttonDidToggle(_ button: ToggleButton) {
         item.isFavorited = button.isSelected
         FavoriteStore.shared.update(item)
+        delegate?.didFavoriteItem()
         Analytics.logEvent("favorited_food_item", parameters: ["food_item" : item.name])
-
     }
 }

--- a/berkeleyMobileiOS/Classes/Dining/DiningMenu/DiningMenuViewController.swift
+++ b/berkeleyMobileiOS/Classes/Dining/DiningMenu/DiningMenuViewController.swift
@@ -6,11 +6,10 @@ fileprivate let kColorNavy = UIColor(red: 23/255.0, green: 85/255.0, blue: 122/2
 /**
  * ViewController to display list of menus of one MealType at a certain DiningHall.
  */
-class DiningMenuViewController: UIViewController, RequiresData, DelegatesScroll, UITableViewDataSource, UITableViewDelegate
+class DiningMenuViewController: UIViewController, RequiresData, DelegatesScroll, UITableViewDataSource, UITableViewDelegate, DiningItemCellDelegate
 {
     // Data
     private var shift: MealShift!
-    
     
     //UI
     @IBOutlet private weak var hoursView: UIView!
@@ -18,6 +17,13 @@ class DiningMenuViewController: UIViewController, RequiresData, DelegatesScroll,
     
     @IBOutlet private(set) weak var tableView: UITableView!
     
+    // ========================================
+    // MARK: - DiningItemCellDelegate
+    // ========================================
+    
+    func didFavoriteItem() {
+        sortBy = .favorites
+    }
     
     // ========================================
     // MARK: - RequiresData
@@ -37,7 +43,6 @@ class DiningMenuViewController: UIViewController, RequiresData, DelegatesScroll,
             tableView?.reloadData()
         }
     }
-    
     
     // ========================================
     // MARK: - DelegatesScroll
@@ -101,7 +106,6 @@ class DiningMenuViewController: UIViewController, RequiresData, DelegatesScroll,
         self.hoursLabel.text = self.shift.hours?.description(withFormatter: formatter)
     }
     
-    
     // ========================================
     // MARK: - UITableViewDataSource
     // ========================================
@@ -119,9 +123,11 @@ class DiningMenuViewController: UIViewController, RequiresData, DelegatesScroll,
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell
     {
         let cell = tableView.dequeueReusableCell(withIdentifier: className(DiningItemCell.self)) as! DiningItemCell
+        cell.delegate = self
         cell.setData( shift.menu[indexPath.row] )
         return cell
     }
+
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 55
     }

--- a/berkeleyMobileiOS/Storyboards/Dining.storyboard
+++ b/berkeleyMobileiOS/Storyboards/Dining.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vwX-1f-TP7">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vwX-1f-TP7">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -73,7 +73,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="meal item" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Yh-nk-XE9">
-                                                    <rect key="frame" x="47" y="18" width="225" height="20"/>
+                                                    <rect key="frame" x="47" y="18.5" width="225" height="19.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.20000000000000001" green="0.37647058823529411" blue="0.47843137254901957" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>


### PR DESCRIPTION
### Problem
When the user favorited a dining item, the item would not move to the top of the list.

### Solution
Re-sorts all the items when a dining item is favorited. This allows the newly favorited item to appear at the top when the table view is refreshed.

Fixes [Issue 90](https://github.com/asuc-octo/berkeley-mobile-ios/issues/90)