### PR TITLE
removed pods from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ xcuserdata/
 
 
 ## Cocoapods
-Pods/
+##Pods/


### PR DESCRIPTION
Due to annoyances having to pod install every time we pull, we're removing pods from the git ignore. 