### PR TITLE
Make phone numbers, emails, and websites clickable

### DIFF
--- a/berkeleyMobileiOS.xcodeproj/project.pbxproj
+++ b/berkeleyMobileiOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		137640C02190160F0044BC74 /* TappableInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137640BF2190160F0044BC74 /* TappableInfoTableViewCell.swift */; };
 		282A4EEA1E63839200480201 /* GymClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282A4EE91E63839200480201 /* GymClass.swift */; };
 		282A4EEC1E63859900480201 /* GymClassDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282A4EEB1E63859900480201 /* GymClassDataSource.swift */; };
 		284A3C851E316F1F00685A01 /* AddressCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 284A3C841E316F1F00685A01 /* AddressCell.swift */; };
@@ -130,6 +131,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		137640BF2190160F0044BC74 /* TappableInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TappableInfoTableViewCell.swift; sourceTree = "<group>"; };
 		2145738E109E31684887C5EE /* Pods_berkeleyMobileiOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_berkeleyMobileiOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		282A4EE91E63839200480201 /* GymClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GymClass.swift; sourceTree = "<group>"; };
 		282A4EEB1E63859900480201 /* GymClassDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GymClassDataSource.swift; sourceTree = "<group>"; };
@@ -273,6 +275,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		137640BE219015D70044BC74 /* Tappable */ = {
+			isa = PBXGroup;
+			children = (
+				137640BF2190160F0044BC74 /* TappableInfoTableViewCell.swift */,
+			);
+			path = Tappable;
+			sourceTree = "<group>";
+		};
 		411DD3D8207EC7DF0081C7A1 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
@@ -375,6 +385,7 @@
 				4EC865D91E9C275D00B51E30 /* Search */,
 				4E4EC13B1E50470F000C63ED /* Resource */,
 				4E4EC1481E5118C9000C63ED /* Favorites */,
+				137640BE219015D70044BC74 /* Tappable */,
 				4E505D2D1DD05A65004AC6C9 /* Academics */,
 				4E505D391DD05A65004AC6C9 /* Recreation */,
 				4E505D3B1DD05A65004AC6C9 /* Transit */,
@@ -873,6 +884,7 @@
 				4E4E7D0C1E5A7ED000A45586 /* DiningHallViewController.swift in Sources */,
 				413E19E6208EEECA009D6621 /* LibraryMapTableViewCell.swift in Sources */,
 				555D40E92051FD3000EA1E1C /* GymNavigationController.swift in Sources */,
+				137640C02190160F0044BC74 /* TappableInfoTableViewCell.swift in Sources */,
 				4E4E7D0A1E5A6ACA00A45586 /* ResourceDetailProvider.swift in Sources */,
 				B5F25D211DE2B6DF0084A5C7 /* Library.swift in Sources */,
 				B5F25D251DE8BFC60084A5C7 /* CampusResource.swift in Sources */,

--- a/berkeleyMobileiOS/Classes/Academics/AcademicsCells/CampusResourceDetailCell.swift
+++ b/berkeleyMobileiOS/Classes/Academics/AcademicsCells/CampusResourceDetailCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class CampusResourceDetailCell: UITableViewCell {
+class CampusResourceDetailCell: TappableInfoTableViewCell {
 
     @IBOutlet weak var campResIconInfo: UILabel!
     @IBOutlet weak var campResIconImage: UIImageView!

--- a/berkeleyMobileiOS/Classes/Academics/AcademicsCells/LibraryDetailCell.swift
+++ b/berkeleyMobileiOS/Classes/Academics/AcademicsCells/LibraryDetailCell.swift
@@ -8,8 +8,8 @@
 
 import UIKit
 
-class LibraryDetailCell: UITableViewCell {
-
+class LibraryDetailCell: TappableInfoTableViewCell {
+    
     @IBOutlet weak var libraryIconImage: UIImageView!
     @IBOutlet weak var libraryIconInfo: UILabel!
 

--- a/berkeleyMobileiOS/Classes/Academics/AcademicsCells/WeeklyTimesTableViewCell.swift
+++ b/berkeleyMobileiOS/Classes/Academics/AcademicsCells/WeeklyTimesTableViewCell.swift
@@ -8,7 +8,13 @@
 
 import UIKit
 
+protocol WeeklyTimesCellDelegate {
+    func expandRow(cell: WeeklyTimesTableViewCell)
+}
+
 class WeeklyTimesTableViewCell: UITableViewCell {
+    
+    var delegate: WeeklyTimesCellDelegate?
 
     @IBOutlet weak var icon: UIImageView!
     
@@ -21,8 +27,9 @@ class WeeklyTimesTableViewCell: UITableViewCell {
     @IBOutlet weak var timeTableView: UITableView!
     
     @IBAction func expand(_ sender: Any) {
-        
-        
+        if let vc = delegate {
+            vc.expandRow(cell: self)
+        }
     }
     
     

--- a/berkeleyMobileiOS/Classes/Academics/AcademicsViewController/CampusResourceViewController.swift
+++ b/berkeleyMobileiOS/Classes/Academics/AcademicsViewController/CampusResourceViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 import Material
 import GoogleMaps
 import Firebase
+import MessageUI
+
 class CampusResourceViewController: UIViewController, CLLocationManagerDelegate, GMSMapViewDelegate {
     
     @IBOutlet weak var campResTitle: UILabel!
@@ -24,6 +26,7 @@ class CampusResourceViewController: UIViewController, CLLocationManagerDelegate,
         UIImage(named:"location_2.0.png")!,
         UIImage(named:"info_2.0.png")!
     ]
+    var types: [TappableInfoType] = [.none, .phone, .none, .none]
     
     var campResInfo = [String]()
     override func viewDidAppear(_ animated: Bool) {
@@ -134,14 +137,24 @@ extension CampusResourceViewController: UITableViewDelegate, UITableViewDataSour
         campResInfoCell.campResIconImage.image = iconImages[indexPath.row]
         campResInfoCell.campResIconInfo.text = campResInfo[indexPath.row]
         campResInfoCell.campResIconInfo.font = UIFont.systemFont(ofSize: 16, weight: UIFontWeightMedium)
+        campResInfoCell.info = campResInfoCell.campResIconInfo.text
+        campResInfoCell.type = types[indexPath.row]
+        campResInfoCell.delegate = self
         
         return campResInfoCell
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let cell  = tableView.cellForRow(at: indexPath)
-        cell?.selectionStyle = .none
+        if let cell = tableView.cellForRow(at: indexPath) as? CampusResourceDetailCell {
+            cell.didTap()
+        }
     }
+}
+
+extension CampusResourceViewController: MFMailComposeViewControllerDelegate {
     
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true, completion: nil)
+    }
 }
 

--- a/berkeleyMobileiOS/Classes/Academics/AcademicsViewController/LibraryViewController.swift
+++ b/berkeleyMobileiOS/Classes/Academics/AcademicsViewController/LibraryViewController.swift
@@ -9,15 +9,18 @@ import UIKit
 import GoogleMaps
 import Material
 import Firebase
+import MessageUI
+
 fileprivate let kColorGreen = UIColor(red: 16/255.0, green: 161/255.0, blue: 0, alpha:1)
 fileprivate let kColorRed = UIColor.red
 
-class LibraryViewController: UIViewController, GMSMapViewDelegate, CLLocationManagerDelegate {
+class LibraryViewController: UIViewController, GMSMapViewDelegate, CLLocationManagerDelegate, WeeklyTimesCellDelegate {
     
     var library: Library!
     var locationManager = CLLocationManager()
     var iconImages = [UIImage]()
     var libInfo = [String]()
+    var types = [TappableInfoType]()
     var weeklyTimes = [String]()
     var daysOfWeek = [String]()
     var expandRow: Bool!
@@ -48,6 +51,8 @@ class LibraryViewController: UIViewController, GMSMapViewDelegate, CLLocationMan
         libInfo.append(getLibraryStatusHours())
         libInfo.append(getLibraryPhoneNumber())
         libInfo.append(getLibraryLoc())
+        
+        types = [.none, .phone, .none]
         
         libTableView.delegate = self
         libTableView.dataSource = self
@@ -291,6 +296,7 @@ extension LibraryViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.row == 0 {
             let cell = libTableView.dequeueReusableCell(withIdentifier: "dropdown", for: indexPath) as! WeeklyTimesTableViewCell
+            cell.delegate = self
             cell.icon.image = iconImages[indexPath.row]
             if self.library.isOpen {
                 cell.day.text = "Open"
@@ -318,6 +324,9 @@ extension LibraryViewController: UITableViewDataSource, UITableViewDelegate {
             libraryInfoCell.libraryIconImage.image = iconImages[indexPath.row]
             libraryInfoCell.libraryIconInfo.text = libInfo[indexPath.row]
             libraryInfoCell.libraryIconInfo.font = UIFont.systemFont(ofSize: 16, weight: UIFontWeightMedium)
+            libraryInfoCell.info = libraryInfoCell.libraryIconInfo.text
+            libraryInfoCell.type = types[indexPath.row]
+            libraryInfoCell.delegate = self
             return libraryInfoCell
         }
     }
@@ -325,9 +334,23 @@ extension LibraryViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath.row == 0 {
             let cell = tableView.cellForRow(at: indexPath) as! WeeklyTimesTableViewCell
-            expandRow = !expandRow
-            tableView.reloadData()
+            expandRow(cell: cell)
+        } else if let cell = tableView.cellForRow(at: indexPath) as? LibraryDetailCell {
+            cell.didTap()
         }
     }
     
+    // WeeklyTimesCellDelegate
+    
+    func expandRow(cell: WeeklyTimesTableViewCell) {
+        expandRow = !expandRow
+        libTableView.reloadData()
+    }
+}
+
+extension LibraryViewController: MFMailComposeViewControllerDelegate {
+    
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true, completion: nil)
+    }
 }

--- a/berkeleyMobileiOS/Classes/Recreation/RecreationCells/GymInformationTableViewCell.swift
+++ b/berkeleyMobileiOS/Classes/Recreation/RecreationCells/GymInformationTableViewCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class GymInformationTableViewCell: UITableViewCell {
+class GymInformationTableViewCell: TappableInfoTableViewCell {
 
     
     @IBOutlet weak var iconImage: UIImageView!

--- a/berkeleyMobileiOS/Classes/Recreation/SpecificGymViewController.swift
+++ b/berkeleyMobileiOS/Classes/Recreation/SpecificGymViewController.swift
@@ -8,6 +8,8 @@
 import GoogleMaps
 import UIKit
 import Firebase
+import MessageUI
+
 fileprivate let kColorGreen = UIColor(red: 16/255.0, green: 161/255.0, blue: 0, alpha:1)
 fileprivate let kColorRed = UIColor.red
 class SpecificGymViewController: UIViewController, CLLocationManagerDelegate, GMSMapViewDelegate {
@@ -24,6 +26,7 @@ class SpecificGymViewController: UIViewController, CLLocationManagerDelegate, GM
     
     var iconImages = [UIImage]()
     var gymInfo = [String]()
+    var types = [TappableInfoType]()
     override func viewDidAppear(_ animated: Bool) {
         Analytics.logEvent("opened_gym", parameters: ["name": gym.name])
     }
@@ -38,13 +41,15 @@ class SpecificGymViewController: UIViewController, CLLocationManagerDelegate, GM
      
         iconImages.append(#imageLiteral(resourceName: "hours_2.0"))
         iconImages.append(#imageLiteral(resourceName: "phone_2.0"))
-        iconImages.append(#imageLiteral(resourceName: "location_2.0"))
         iconImages.append(#imageLiteral(resourceName: "info_2.0"))
+        iconImages.append(#imageLiteral(resourceName: "location_2.0"))
         
         gymInfo.append(getGymStatusHours())
         gymInfo.append(getGymPhoneNumber())
         gymInfo.append(getGymWebsite())
         gymInfo.append(getGymLoc())
+        
+        types = [.none, .phone, .website, .none]
         
         gymInfoTableview.delegate = self
         gymInfoTableview.dataSource = self
@@ -191,25 +196,29 @@ extension SpecificGymViewController: UITableViewDataSource, UITableViewDelegate 
         infoCell.iconImage.image = iconImages[indexPath.row]
         infoCell.iconInfo.text = gymInfo[indexPath.row]
         infoCell.iconInfo.font = UIFont.systemFont(ofSize: 16, weight: UIFontWeightMedium)
+        infoCell.info = infoCell.iconInfo.text
+        infoCell.type = types[indexPath.row]
+        infoCell.delegate = self
         return infoCell
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let cell  = tableView.cellForRow(at: indexPath)
-        cell?.selectionStyle = .none
-        
-        if indexPath.row == 1 {
-//            callGym()
-        } else if indexPath.row == 2 {
-//            viewGymWebsite()
-        } else if indexPath.row == 3 {
-//            getMap()
+        if let cell = tableView.cellForRow(at: indexPath) as? GymInformationTableViewCell {
+            cell.didTap()
         }
     }
+    
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if indexPath.row == 4 {
             return 300
         }
         return 55
+    }
+}
+
+extension SpecificGymViewController: MFMailComposeViewControllerDelegate {
+    
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true, completion: nil)
     }
 }

--- a/berkeleyMobileiOS/Classes/Tappable/TappableInfoTableViewCell.swift
+++ b/berkeleyMobileiOS/Classes/Tappable/TappableInfoTableViewCell.swift
@@ -64,7 +64,7 @@ class TappableInfoTableViewCell: UITableViewCell {
     }
     
     func email(address: String) {
-        if !MFMailComposeViewController.canSendMail() {
+        if MFMailComposeViewController.canSendMail() {
             let mail = MFMailComposeViewController()
             mail.mailComposeDelegate = delegate
             mail.setToRecipients([address])

--- a/berkeleyMobileiOS/Classes/Tappable/TappableInfoTableViewCell.swift
+++ b/berkeleyMobileiOS/Classes/Tappable/TappableInfoTableViewCell.swift
@@ -1,0 +1,81 @@
+//
+//  TappableInfoTableViewCell.swift
+//  berkeleyMobileiOS
+//
+//  Created by Kevin Hu on 11/4/18.
+//  Copyright © 2018 org.berkeleyMobile. All rights reserved.
+//
+
+import UIKit
+import MessageUI
+
+enum TappableInfoType {
+    case phone
+    case email
+    case website
+    case none
+}
+
+class TappableInfoTableViewCell: UITableViewCell {
+    
+    var delegate: (UIViewController & MFMailComposeViewControllerDelegate)?
+    var type = TappableInfoType.none
+    var info: String!
+    
+    func formattedAs(_ type: TappableInfoType, str: String) -> Bool {
+        let regex: String
+        switch type {
+        case .phone:
+            regex = "(\\+\\d{1,2}\\s?)?\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]{0,3}\\d{4}"
+        case .email:
+            regex = "[^\\s@]+@[^\\s@]+.[^\\s@]+"
+        case .website:
+            regex = "[^\\s@]+.[^\\s@]+"
+        default:
+            return true
+        }
+        
+        return str.range(of: regex, options: .regularExpression) != nil
+    }
+    
+    func didTap() {
+        if info == nil || !formattedAs(type, str: info) {
+            return
+        }
+        
+        switch type {
+        case .phone:
+            call(number: info)
+        case .email:
+            email(address: info)
+        case .website:
+            website(address: info)
+        default:
+            return
+        }
+    }
+    
+    func call(number: String) {
+        let formatted = number.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+        if let number = URL(string: "tel://" + formatted),
+            UIApplication.shared.canOpenURL(number) {
+            UIApplication.shared.open(number)
+        }
+    }
+    
+    func email(address: String) {
+        if !MFMailComposeViewController.canSendMail() {
+            let mail = MFMailComposeViewController()
+            mail.mailComposeDelegate = delegate
+            mail.setToRecipients([address])
+            delegate?.present(mail, animated: true)
+        }
+    }
+    
+    func website(address: String) {
+        if let website = URL(string: "http://" + address),
+            UIApplication.shared.canOpenURL(website) {
+            UIApplication.shared.open(website)
+        }
+    }
+}

--- a/berkeleyMobileiOS/Storyboards/Academics.storyboard
+++ b/berkeleyMobileiOS/Storyboards/Academics.storyboard
@@ -55,11 +55,11 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="260"/>
                                 <color key="backgroundColor" red="0.074509803921568626" green="0.1764705882352941" blue="0.60784313725490191" alpha="1" colorSpace="calibratedRGB"/>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" alwaysBounceVertical="YES" pagingEnabled="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HPH-0a-syO">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" alwaysBounceVertical="YES" pagingEnabled="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HPH-0a-syO">
                                 <rect key="frame" x="0.0" y="260" width="375" height="363"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="campusResourceDetail" rowHeight="80" id="vde-kb-vZ7" customClass="CampusResourceDetailCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="campusResourceDetail" rowHeight="80" id="vde-kb-vZ7" customClass="CampusResourceDetailCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="80"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vde-kb-vZ7" id="Zzx-fn-wbe">
@@ -101,7 +101,7 @@
                                             <outlet property="campResIconInfo" destination="gTs-ST-qpV" id="MBS-hn-mkr"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="mapTable" id="bE0-fJ-aI7" customClass="MapTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="mapTable" id="bE0-fJ-aI7" customClass="MapTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="108" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bE0-fJ-aI7" id="0YU-mT-nmT">
@@ -287,7 +287,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v5U-rx-tEX">
-                                                    <rect key="frame" x="165" y="45" width="167" height="20"/>
+                                                    <rect key="frame" x="165" y="44.5" width="167" height="20"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="20" id="8vx-Mu-uDh"/>
                                                     </constraints>
@@ -452,7 +452,7 @@
                                 <rect key="frame" x="0.0" y="260" width="375" height="407"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="libraryCell" rowHeight="55" id="TTB-Rr-kqi" customClass="LibraryDetailCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="libraryCell" rowHeight="55" id="TTB-Rr-kqi" customClass="LibraryDetailCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TTB-Rr-kqi" id="H1S-3J-Duy">
@@ -533,11 +533,11 @@
                                                         <action selector="expand:" destination="LKm-uf-A5V" eventType="touchUpInside" id="mRa-NP-3Pg"/>
                                                     </connections>
                                                 </button>
-                                                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="GtL-mk-Ebh">
+                                                <tableView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="GtL-mk-Ebh">
                                                     <rect key="frame" x="15" y="72.5" width="345" height="82"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <prototypes>
-                                                        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="timeCell" rowHeight="35" id="AOE-CZ-Cjd" customClass="TimeTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
+                                                        <tableViewCell opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="timeCell" rowHeight="35" id="AOE-CZ-Cjd" customClass="TimeTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="28" width="345" height="35"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AOE-CZ-Cjd" id="YhI-qJ-cPP">
@@ -597,7 +597,7 @@
                                             <outlet property="timeTableView" destination="GtL-mk-Ebh" id="OCk-mW-QBf"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="librarymapTable" id="PUu-xT-wYx" customClass="LibraryMapTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="librarymapTable" id="PUu-xT-wYx" customClass="LibraryMapTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="238" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PUu-xT-wYx" id="YCn-rF-HU5">

--- a/berkeleyMobileiOS/Storyboards/Gym.storyboard
+++ b/berkeleyMobileiOS/Storyboards/Gym.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -148,7 +147,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yef-or-lFU">
-                                                <rect key="frame" x="157.5" y="428.5" width="61" height="22.5"/>
+                                                <rect key="frame" x="157" y="428.5" width="61" height="20"/>
                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -185,31 +184,31 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2b-5n-ISs">
-                                                            <rect key="frame" x="22" y="8" width="31.5" height="17.5"/>
+                                                            <rect key="frame" x="22" y="8" width="31.5" height="15.5"/>
                                                             <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="13"/>
                                                             <color key="textColor" red="0.35686274509803922" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GoW-aF-bty">
-                                                            <rect key="frame" x="125" y="8.5" width="34.5" height="16.5"/>
+                                                            <rect key="frame" x="125" y="7.5" width="34.5" height="16.5"/>
                                                             <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="14"/>
                                                             <color key="textColor" red="0.35686274509803922" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZwV-aI-OXB">
-                                                            <rect key="frame" x="330" y="9" width="29" height="16"/>
+                                                            <rect key="frame" x="330" y="8.5" width="29" height="14.5"/>
                                                             <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                             <color key="textColor" red="0.35686274509803922" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Aa3-Du-qwg">
-                                                            <rect key="frame" x="330" y="22.5" width="29" height="16"/>
+                                                            <rect key="frame" x="330" y="22.5" width="29" height="14.5"/>
                                                             <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                             <color key="textColor" red="0.35686274509803922" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RMY-kI-y9S">
-                                                            <rect key="frame" x="125" y="28" width="28.5" height="4.5"/>
+                                                            <rect key="frame" x="125" y="27" width="28.5" height="5.5"/>
                                                             <fontDescription key="fontDescription" name="Roboto-Light" family="Roboto" pointSize="12"/>
                                                             <color key="textColor" red="0.35686274509803922" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -292,7 +291,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zW0-SK-OST">
-                                                            <rect key="frame" x="16" y="189" width="29" height="16"/>
+                                                            <rect key="frame" x="16" y="189" width="29" height="14.5"/>
                                                             <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -467,11 +466,11 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="260"/>
                                 <color key="backgroundColor" red="0.074509803920000006" green="0.1764705882" blue="0.60784313729999995" alpha="1" colorSpace="calibratedRGB"/>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" alwaysBounceVertical="YES" pagingEnabled="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HOg-Gg-9ub">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" alwaysBounceVertical="YES" pagingEnabled="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HOg-Gg-9ub">
                                 <rect key="frame" x="0.0" y="260" width="375" height="407"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="gymInfoCell" rowHeight="55" id="gyQ-cA-14B" customClass="GymInformationTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="gymInfoCell" rowHeight="55" id="gyQ-cA-14B" customClass="GymInformationTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gyQ-cA-14B" id="xUC-xB-gxR">
@@ -486,7 +485,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0jf-iF-adH">
-                                                    <rect key="frame" x="53" y="16" width="314" height="22.5"/>
+                                                    <rect key="frame" x="53" y="16" width="314" height="23"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -513,7 +512,7 @@
                                             <outlet property="iconInfo" destination="0jf-iF-adH" id="ipv-f0-U8Y"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="mapTable" id="g4I-oL-Cgm" customClass="MapTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="mapTable" id="g4I-oL-Cgm" customClass="MapTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="83" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="g4I-oL-Cgm" id="gud-Jo-8KJ">
@@ -521,7 +520,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="CDg-GW-Icu" customClass="GMSMapView">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 </view>
                                             </subviews>
@@ -568,7 +567,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xCB-ab-lpt">
-                                <rect key="frame" x="16" y="222.5" width="351" height="29.5"/>
+                                <rect key="frame" x="16" y="219" width="351" height="33"/>
                                 <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="25"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>


### PR DESCRIPTION
The detail views for libraries, gyms, and campus resources currently do not provide any response when information is tapped on. This PR allows phone numbers in these views to prompt the user to make a phone call, tapping email addresses now opens a window to compose a new email, and tapping a website address will open the website in Safari.

Fixes #102 