### PR TITLE
Remove navigation bar

### DIFF
--- a/berkeleyMobileiOS/Classes/Resource/ResourceGroupViewController.swift
+++ b/berkeleyMobileiOS/Classes/Resource/ResourceGroupViewController.swift
@@ -28,8 +28,6 @@ class ResourceGroupViewController: UIViewController, IBInitializable, UITableVie
     
     // UI
     override var preferredStatusBarStyle: UIStatusBarStyle { return .lightContent }
-    private weak var navbar: UINavigationBar?
-    private var pseudoNavbar: UIView!
     private var searchBar = UISearchBar()
     let searchDropDown = DropDown()
     
@@ -72,7 +70,6 @@ class ResourceGroupViewController: UIViewController, IBInitializable, UITableVie
     {
         super.viewDidLoad()
         
-        self.setupNavigationBar()
         self.setupSearchBar()
         self.setupActivityIndicator()
         
@@ -137,8 +134,6 @@ class ResourceGroupViewController: UIViewController, IBInitializable, UITableVie
                 print("Error")
             }
         }
-        self.navbar?.hideHairline = true
-        self.navbar?.setTransparent(true)
         setStatusBarStyle(self.preferredStatusBarStyle)
         for vc in (self.pageTabBarController?.viewControllers)! {
             if (type(of: vc) == BearTransitNavigationController.self) {
@@ -154,49 +149,6 @@ class ResourceGroupViewController: UIViewController, IBInitializable, UITableVie
             addLoadingView()
         }
     }
-    /// Place the pseudoNavbar backdrop behind the navbar.
-    override func viewDidLayoutSubviews()
-    {
-        super.viewDidLayoutSubviews()
-        
-        let view = self.view!
-        
-        let navbarMaxY = self.navbar?.frame.maxY ?? 0
-        let eliminateSpace: CGFloat = 12
-        self.pseudoNavbar.frame = CGRect(x: 0, y: -navbarMaxY - eliminateSpace, width: view.width, height: navbarMaxY + 10)
-    }
-    
-    
-    // ========================================
-    // MARK: - Setup
-    // ========================================
-    /**
-     * Makes the original UINavigationBar clear and inserts another view with solid color.
-     * This is to prevent strage transitions when pushing/popping ViewControllers with clear navbar.
-     * 
-     * - Attention: Transparent UINavigationBar and pseudoNavbar backdrop is a temporary solution.
-     *      NavigationController and bar should be reworked into a custom class.
-     */
-    private func setupNavigationBar()
-    {
-        // Insert a pseudo-background
-        self.pseudoNavbar = UIView()
-        self.pseudoNavbar.backgroundColor = kColorNavy
-        self.view!.addSubview(self.pseudoNavbar)
-        
-        
-        // Configure the navigationBar.
-        self.navbar = self.navigationController?.navigationBar
-        guard let navbar = self.navbar else {
-            return
-        } 
-        
-        // White content
-        navbar.tintColor = .white
-        navbar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
-        self.navigationItem.backBarButtonItem = UIBarButtonItem.init(title: "", style: .plain, target: nil, action: nil)
-        
-    }
     
     // ========================================
     // MARK: - UISearchBar Setup
@@ -207,17 +159,6 @@ class ResourceGroupViewController: UIViewController, IBInitializable, UITableVie
     private func setupSearchBar()
     {
         // Search bar
-
-        
-        var backView = UIView(frame: CGRect(x: 0, y: 0, width: (self.navigationController?.navigationBar.frame.width)!, height: (self.navigationController?.navigationBar.frame.height)!))
-        let image : UIImage = #imageLiteral(resourceName: "bearsmallmed")
-        let imageView = UIImageView(frame: CGRect(x: ((self.navigationController?.navigationBar.frame.width)! - 36) / 2, y: 2, width: 36, height: 19))
-        imageView.contentMode = .scaleAspectFit
-        imageView.image = image
-        //        self.navigationItem.titleView = imageView
-        
-        backView.addSubview(imageView)
-        self.navigationItem.titleView = backView
         
 //        let iv = UIImageView.init(frame: CGRect.init(x: 0, y: 0, width: 24, height: 24))
 //        iv.image = #imageLiteral(resourceName: "bear")

--- a/berkeleyMobileiOS/Storyboards/Academics.storyboard
+++ b/berkeleyMobileiOS/Storyboards/Academics.storyboard
@@ -17,9 +17,8 @@
         <!--Academic Navigation Controller-->
         <scene sceneID="osT-yV-V01">
             <objects>
-                <navigationController storyboardIdentifier="AcademicNavigationController" id="lIN-m5-0oJ" customClass="AcademicNavigationController" customModule="berkeleyMobileiOS" customModuleProvider="target" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="AcademicNavigationController" navigationBarHidden="YES" id="lIN-m5-0oJ" customClass="AcademicNavigationController" customModule="berkeleyMobileiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="kcM-Cs-b7p">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="2ZU-GY-IrF">
@@ -155,7 +154,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hdQ-zN-Z0b">
-                                <rect key="frame" x="16" y="219" width="351" height="33"/>
+                                <rect key="frame" x="16" y="222.5" width="351" height="29.5"/>
                                 <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="25"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
@@ -211,14 +210,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rbo-lu-ysz">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="|" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zKS-em-CwJ">
-                                <rect key="frame" x="126" y="92" width="12" height="45"/>
+                                <rect key="frame" x="126" y="26" width="12" height="41"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="33"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F1U-vI-hTe">
-                                <rect key="frame" x="18" y="94" width="102" height="47"/>
+                                <rect key="frame" x="18" y="28" width="102" height="43"/>
                                 <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="26"/>
                                 <state key="normal" title="Libraries">
                                     <color key="titleColor" red="0.0" green="0.33333333333333331" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
@@ -228,7 +231,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m66-2f-FU2">
-                                <rect key="frame" x="146" y="94" width="123" height="47"/>
+                                <rect key="frame" x="146" y="28" width="123" height="43"/>
                                 <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="26"/>
                                 <state key="normal" title="Resources">
                                     <color key="titleColor" red="0.0" green="0.33333333329999998" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
@@ -237,16 +240,8 @@
                                     <action selector="resourceModeSelected:" destination="adv-ic-IZc" eventType="touchUpInside" id="vGe-H2-ohv"/>
                                 </connections>
                             </button>
-                            <imageView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="BZo-6g-Oo2">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="86"/>
-                                <color key="backgroundColor" red="0.074509803921568626" green="0.20000000000000001" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <color key="tintColor" red="0.0" green="0.20000000000000001" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="86" id="xpI-Rh-eDp"/>
-                                </constraints>
-                            </imageView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Q2k-Dw-j7I">
-                                <rect key="frame" x="0.0" y="149" width="375" height="518"/>
+                                <rect key="frame" x="0.0" y="79" width="375" height="588"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="resource" rowHeight="85" id="pWA-wx-zs9" customClass="ResourceTableViewCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
@@ -386,35 +381,29 @@
                                     <outlet property="delegate" destination="adv-ic-IZc" id="sJq-TH-EOS"/>
                                 </connections>
                             </tableView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bearsmallmed" translatesAutoresizingMaskIntoConstraints="NO" id="6xk-dm-M53">
-                                <rect key="frame" x="169.5" y="47" width="36" height="19"/>
-                            </imageView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.0" green="0.20000000000000001" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="zKS-em-CwJ" firstAttribute="top" secondItem="BZo-6g-Oo2" secondAttribute="bottom" constant="6" id="3ZH-Ml-Ss9"/>
-                            <constraint firstItem="F1U-vI-hTe" firstAttribute="top" secondItem="BZo-6g-Oo2" secondAttribute="bottom" constant="8" id="53b-RV-FUr"/>
-                            <constraint firstItem="6xk-dm-M53" firstAttribute="centerX" secondItem="L6L-xv-Izl" secondAttribute="centerX" id="6AF-Oi-RuN"/>
+                            <constraint firstItem="zKS-em-CwJ" firstAttribute="top" secondItem="56H-xo-PU5" secondAttribute="bottom" constant="6" id="3ZH-Ml-Ss9"/>
+                            <constraint firstItem="F1U-vI-hTe" firstAttribute="top" secondItem="56H-xo-PU5" secondAttribute="bottom" constant="8" id="53b-RV-FUr"/>
                             <constraint firstItem="Q2k-Dw-j7I" firstAttribute="top" secondItem="m66-2f-FU2" secondAttribute="bottom" constant="8" id="6Ks-gq-NBL"/>
                             <constraint firstItem="Q2k-Dw-j7I" firstAttribute="top" secondItem="F1U-vI-hTe" secondAttribute="bottom" constant="8" id="8yg-kn-LYx"/>
                             <constraint firstItem="m66-2f-FU2" firstAttribute="leading" secondItem="zKS-em-CwJ" secondAttribute="trailing" constant="8" id="FAf-c8-KPj"/>
-                            <constraint firstItem="6xk-dm-M53" firstAttribute="bottom" secondItem="BZo-6g-Oo2" secondAttribute="bottom" constant="-20" id="MRP-Bd-33n"/>
+                            <constraint firstItem="rbo-lu-ysz" firstAttribute="leading" secondItem="L6L-xv-Izl" secondAttribute="leading" id="Pjd-Bp-wO1"/>
+                            <constraint firstAttribute="trailing" secondItem="rbo-lu-ysz" secondAttribute="trailing" id="b9I-Lh-9XX"/>
                             <constraint firstItem="F1U-vI-hTe" firstAttribute="leading" secondItem="L6L-xv-Izl" secondAttribute="leading" constant="18" id="blz-MD-zbw"/>
-                            <constraint firstItem="m66-2f-FU2" firstAttribute="top" secondItem="BZo-6g-Oo2" secondAttribute="bottom" constant="8" id="g05-af-O1y"/>
-                            <constraint firstItem="BZo-6g-Oo2" firstAttribute="top" secondItem="L6L-xv-Izl" secondAttribute="top" id="hXW-dR-yDf"/>
+                            <constraint firstItem="2Lh-fb-QQh" firstAttribute="top" secondItem="rbo-lu-ysz" secondAttribute="bottom" id="fn0-WG-qM8"/>
+                            <constraint firstItem="m66-2f-FU2" firstAttribute="top" secondItem="56H-xo-PU5" secondAttribute="bottom" constant="8" id="g05-af-O1y"/>
+                            <constraint firstItem="rbo-lu-ysz" firstAttribute="top" secondItem="56H-xo-PU5" secondAttribute="bottom" id="iaH-mO-aSE"/>
                             <constraint firstItem="zKS-em-CwJ" firstAttribute="leading" secondItem="F1U-vI-hTe" secondAttribute="trailing" constant="6" id="m2v-up-eoA"/>
                             <constraint firstAttribute="trailing" secondItem="Q2k-Dw-j7I" secondAttribute="trailing" id="mTH-Rv-2ub"/>
                             <constraint firstItem="Q2k-Dw-j7I" firstAttribute="top" secondItem="zKS-em-CwJ" secondAttribute="bottom" constant="12" id="mv6-qO-e6V"/>
                             <constraint firstAttribute="bottom" secondItem="Q2k-Dw-j7I" secondAttribute="bottom" id="oyC-gm-PQw"/>
-                            <constraint firstItem="Q2k-Dw-j7I" firstAttribute="trailing" secondItem="BZo-6g-Oo2" secondAttribute="trailing" id="qbT-Bo-U2S"/>
                             <constraint firstItem="Q2k-Dw-j7I" firstAttribute="leading" secondItem="L6L-xv-Izl" secondAttribute="leading" id="rlj-6r-rxk"/>
-                            <constraint firstItem="Q2k-Dw-j7I" firstAttribute="leading" secondItem="BZo-6g-Oo2" secondAttribute="leading" id="xk4-dd-Hw7"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="gc8-iY-XvV"/>
-                    <nil key="simulatedTopBarMetrics"/>
                     <connections>
-                        <outlet property="banner" destination="BZo-6g-Oo2" id="dpB-Dt-AOR"/>
                         <outlet property="libButton" destination="F1U-vI-hTe" id="mrN-MS-YHN"/>
                         <outlet property="resourceButton" destination="m66-2f-FU2" id="n1t-px-Hoe"/>
                         <outlet property="resourceTableView" destination="Q2k-Dw-j7I" id="L5i-K2-lsX"/>
@@ -697,7 +686,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="bearsmallmed" width="36" height="19"/>
         <image name="forward-arrow" width="31" height="30"/>
         <image name="heart_empty" width="32" height="32"/>
         <image name="heart_filled" width="32" height="32"/>

--- a/berkeleyMobileiOS/Storyboards/Gym.storyboard
+++ b/berkeleyMobileiOS/Storyboards/Gym.storyboard
@@ -36,7 +36,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pgd-Jo-c56">
-                                <rect key="frame" x="0.0" y="86" width="375" height="581"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2R2-Az-6gw">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="657.5"/>
@@ -383,33 +383,13 @@
                                     <constraint firstAttribute="bottom" secondItem="2R2-Az-6gw" secondAttribute="bottom" id="r9I-jg-PVj"/>
                                 </constraints>
                             </scrollView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iZE-Ki-nbc">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="86"/>
-                                <color key="backgroundColor" red="0.074509803921568626" green="0.20000000000000001" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <color key="tintColor" red="0.0" green="0.20000000000000001" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="86" id="Bvx-NX-oHh"/>
-                                </constraints>
-                            </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bearsmallmed" translatesAutoresizingMaskIntoConstraints="NO" id="Qjs-aD-AeQ">
-                                <rect key="frame" x="169.5" y="46" width="36" height="19"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="36" id="SqS-v9-vVQ"/>
-                                    <constraint firstAttribute="height" constant="19" id="Vix-g3-4Ht"/>
-                                </constraints>
-                            </imageView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.0" green="0.20000000000000001" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
+                            <constraint firstItem="pgd-Jo-c56" firstAttribute="top" secondItem="gQB-Fl-g31" secondAttribute="bottom" id="2fD-Uh-Zhf"/>
                             <constraint firstItem="pgd-Jo-c56" firstAttribute="leading" secondItem="4BM-v4-wyg" secondAttribute="leading" id="3R5-Im-kEY"/>
                             <constraint firstAttribute="trailing" secondItem="pgd-Jo-c56" secondAttribute="trailing" id="DDO-s2-CIV"/>
-                            <constraint firstItem="pgd-Jo-c56" firstAttribute="top" secondItem="iZE-Ki-nbc" secondAttribute="bottom" id="JvC-pn-f3e"/>
-                            <constraint firstItem="Qjs-aD-AeQ" firstAttribute="top" secondItem="iZE-Ki-nbc" secondAttribute="bottom" constant="-40" id="L4v-UB-JYH"/>
-                            <constraint firstAttribute="trailing" secondItem="iZE-Ki-nbc" secondAttribute="trailing" id="Mm2-dL-VRy"/>
-                            <constraint firstItem="Qjs-aD-AeQ" firstAttribute="centerX" secondItem="iZE-Ki-nbc" secondAttribute="centerX" id="Tv1-2N-sM5"/>
-                            <constraint firstItem="iZE-Ki-nbc" firstAttribute="top" secondItem="4BM-v4-wyg" secondAttribute="top" id="YM0-yK-roF"/>
                             <constraint firstItem="1h6-4n-2fC" firstAttribute="width" secondItem="4BM-v4-wyg" secondAttribute="width" id="aHI-1b-JhV"/>
-                            <constraint firstItem="iZE-Ki-nbc" firstAttribute="leading" secondItem="4BM-v4-wyg" secondAttribute="leading" id="jFP-Xk-4ko"/>
                             <constraint firstAttribute="bottom" secondItem="pgd-Jo-c56" secondAttribute="bottom" id="sP3-bT-TOP"/>
                         </constraints>
                     </view>
@@ -613,7 +593,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="bearsmallmed" width="36" height="19"/>
         <image name="ic_arrow_back_white" width="24" height="24"/>
     </resources>
 </document>

--- a/berkeleyMobileiOS/Storyboards/Resource.storyboard
+++ b/berkeleyMobileiOS/Storyboards/Resource.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -96,9 +95,8 @@
         <!--Resource Navigation Controller-->
         <scene sceneID="ddT-A0-7Nr">
             <objects>
-                <navigationController storyboardIdentifier="ResourceNavigationController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="o8A-Lp-GXR" customClass="ResourceNavigationController" customModule="berkeleyMobileiOS" customModuleProvider="target" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="ResourceNavigationController" useStoryboardIdentifierAsRestorationIdentifier="YES" navigationBarHidden="YES" id="o8A-Lp-GXR" customClass="ResourceNavigationController" customModule="berkeleyMobileiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="qA8-E9-eCE">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -118,11 +116,15 @@
                         <viewControllerLayoutGuide type="bottom" id="Wdr-al-d6r"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="xDO-UD-KCp">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gb7-2h-XXx">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="calibratedRGB"/>
+                            </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" delaysContentTouches="NO" canCancelContentTouches="NO" bouncesZoom="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="278" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gfB-Uh-e7V">
-                                <rect key="frame" x="0.0" y="-12" width="375" height="615"/>
+                                <rect key="frame" x="0.0" y="8" width="375" height="659"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="ResourceGroupCell" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationWidth="0.0" shouldIndentWhileEditing="NO" reuseIdentifier="ResourceGroupCell" id="WKb-eN-ecn" customClass="ResourceGroupCell" customModule="berkeleyMobileiOS" customModuleProvider="target">
@@ -227,9 +229,13 @@
                                 </prototypes>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.0" green="0.20000000000000001" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="Wdr-al-d6r" firstAttribute="top" secondItem="gfB-Uh-e7V" secondAttribute="bottom" id="4LN-hz-hMa"/>
+                            <constraint firstItem="gb7-2h-XXx" firstAttribute="leading" secondItem="xDO-UD-KCp" secondAttribute="leading" id="KXb-1B-7hL"/>
+                            <constraint firstAttribute="bottom" secondItem="gb7-2h-XXx" secondAttribute="bottom" id="NKb-nQ-YyP"/>
+                            <constraint firstItem="gb7-2h-XXx" firstAttribute="top" secondItem="SR9-0k-imp" secondAttribute="bottom" id="Tjs-h3-bCI"/>
+                            <constraint firstAttribute="trailing" secondItem="gb7-2h-XXx" secondAttribute="trailing" id="gl8-Sc-mZN"/>
                             <constraint firstItem="gfB-Uh-e7V" firstAttribute="top" secondItem="SR9-0k-imp" secondAttribute="bottom" constant="-12" id="jVO-jI-CMQ"/>
                             <constraint firstAttribute="trailing" secondItem="gfB-Uh-e7V" secondAttribute="trailing" id="nSA-Ra-4hf"/>
                             <constraint firstItem="gfB-Uh-e7V" firstAttribute="leading" secondItem="xDO-UD-KCp" secondAttribute="leading" id="tHT-jj-xwg"/>
@@ -244,7 +250,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bbS-1n-W2e" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2328.5" y="-849.5"/>
+            <point key="canvasLocation" x="2327.1999999999998" y="-849.62518740629696"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
Removes navigation bar for Gyms, Dining, and Academics. Now looks like the mock-up:

![image](https://user-images.githubusercontent.com/41145903/49053966-425ca380-f1a7-11e8-96a0-bb852e251aaa.png)

Fixes #117 and #99 