### PR TITLE
Migrate Gyms to Firebase

### DIFF
--- a/berkeleyMobileiOS/Classes/Academics/AcademicsDataSource/LibraryDataSource.swift
+++ b/berkeleyMobileiOS/Classes/Academics/AcademicsDataSource/LibraryDataSource.swift
@@ -50,6 +50,9 @@ class LibraryDataSource: ResourceDataSource {
                               imageLink: dict["picture"] as? String,
                               latitude: dict["latitude"] as? Double,
                               longitude: dict["longitude"] as? Double)
+        
+        FavoriteStore.shared.restoreState(for: library)
+        
         return library
     }
     

--- a/berkeleyMobileiOS/Classes/Recreation/Gym.swift
+++ b/berkeleyMobileiOS/Classes/Recreation/Gym.swift
@@ -26,7 +26,8 @@ class Gym: Resource {
     
     var isFavorited: Bool = false
     
-    let address: String
+    let address: String?
+    let phoneNumber: String?
     
     var openingTimeToday: Date? = nil
     var closingTimeToday: Date? = nil
@@ -34,22 +35,19 @@ class Gym: Resource {
     var longitude: Double? = nil
     
     var isOpen: Bool {
-        var status = true
-        if let t = (openingTimeToday) {
-            if t > Date() {
-                status = false
-            }
-        }
-        if let t = (closingTimeToday) {
-            if t < Date() {
-                status = false
+        var status = false
+        if let open = openingTimeToday,
+           let close = closingTimeToday {
+            if Date().isBetween(open, close) || close == open {
+                status = true
             }
         }
         return status
     }
     
-    init(name: String, address: String, imageLink: String?, openingTimeToday: Date?, closingTimeToday: Date?) {
+    init(name: String, address: String?, phoneNumber: String?, imageLink: String?, openingTimeToday: Date?, closingTimeToday: Date?) {
         self.address = address
+        self.phoneNumber = phoneNumber
         self.openingTimeToday = openingTimeToday
         self.closingTimeToday = closingTimeToday
         

--- a/berkeleyMobileiOS/Classes/Recreation/SpecificGymViewController.swift
+++ b/berkeleyMobileiOS/Classes/Recreation/SpecificGymViewController.swift
@@ -93,7 +93,7 @@ class SpecificGymViewController: UIViewController, CLLocationManagerDelegate, GM
         marker.title = gym?.name
         
         var status = "Open"
-        if (self.gym?.closingTimeToday!.compare(NSDate() as Date) == .orderedAscending) {
+        if (!self.gym.isOpen) {
             status = "Closed"
         }
         
@@ -120,10 +120,14 @@ class SpecificGymViewController: UIViewController, CLLocationManagerDelegate, GM
         df.dateFormat = "MM-dd-yyyy HH:mm"
         df.timeZone = TimeZone(abbreviation: "PST")
         
-        let localOpeningTime = dateFormatter.string(from: (self.gym?.openingTimeToday)!)
-        let localClosingTime = dateFormatter.string(from: (self.gym?.closingTimeToday)!)
         
-        let timeRange = localOpeningTime + " to " + localClosingTime
+        var timeRange = ""
+        if let open = self.gym.openingTimeToday,
+            let close = self.gym.closingTimeToday {
+            let localOpeningTime = dateFormatter.string(from: open)
+            let localClosingTime = dateFormatter.string(from: close)
+            timeRange = localOpeningTime + " to " + localClosingTime
+        }
         
         var status = "Open"
         
@@ -136,7 +140,7 @@ class SpecificGymViewController: UIViewController, CLLocationManagerDelegate, GM
     
     
     func getGymPhoneNumber() -> String {
-        var number = ""
+        var number = gym.phoneNumber ?? "(510) 642-7796"
         if (gym?.name.contains("Recreational"))! {
             number = "(510) 643-8038"
             
@@ -146,15 +150,17 @@ class SpecificGymViewController: UIViewController, CLLocationManagerDelegate, GM
         return number
     }
     
+    #warning("Hardcoded websites")
     func getGymWebsite() -> String{
         var website = ""
         
         //Hardcoding websites for gyms
         if (gym?.name.contains("Recreational"))! {
             website = "recsports.berkeley.edu/rsf/"
-            
         } else if (gym?.name.contains("Stadium"))! {
             website = "recsports.berkeley.edu/stadium-fitness-center/"
+        } else {
+            website = "recsports.berkeley.edu"
         }
         return website
     }
@@ -162,7 +168,7 @@ class SpecificGymViewController: UIViewController, CLLocationManagerDelegate, GM
     func getGymLoc() -> String {
         let addr = gym?.address
         let addrArray = addr?.components(separatedBy: ",")
-        return addrArray![0]
+        return addrArray.isNil ? "UC Berkeley" : addrArray![0]
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
Migrates Gyms tab to Firestore (Except Gym classes). No website is provided, so that cell defaults to the recsports url.