### PR TITLE
Search results ui hotfix

### DIFF
--- a/bm-persona/Map/MapViewController.swift
+++ b/bm-persona/Map/MapViewController.swift
@@ -85,7 +85,8 @@ class MapViewController: UIViewController {
         maskView.setConstraintsToView(top: self.view, bottom: self.view, left: self.view, right: self.view)
         mapView.setConstraintsToView(top: self.view, bottom: self.view, left: self.view, right: self.view)
         
-        searchResultsView.setConstraintsToView(top: maskView, bottom: maskView, left: searchBar, right: searchBar)
+        searchResultsView.setConstraintsToView(bottom: maskView, left: searchBar, right: searchBar)
+        self.view.addConstraint(NSLayoutConstraint(item: searchResultsView, attribute: .top, relatedBy: .equal, toItem: searchBar, attribute: .bottom, multiplier: 1, constant: 0))
         
         searchBar.setHeightConstraint(50)
         searchBar.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor).isActive = true


### PR DESCRIPTION
Wow look at me doing PM things hahahah I just wanted to introduce myself to iOS

Moved the search results view down below the search bar (previously went behind it)

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-13 at 23 47 59](https://user-images.githubusercontent.com/6026859/76676931-ad411200-6585-11ea-810d-9e9447f85597.png)

In all seriousness tho keep up the good work <3 iOS popping off