### PR TITLE
Shawn/ui changes

### DIFF
--- a/bm-persona/Common/FilterTableView/FilterTableView.swift
+++ b/bm-persona/Common/FilterTableView/FilterTableView.swift
@@ -44,6 +44,7 @@ class FilterTableView<T>: UIView {
         tableView.contentInset = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
         tableView.setContentOffset(CGPoint(x: 0, y: -5), animated: false)
         tableView.contentInsetAdjustmentBehavior = .never
+        tableView.showsVerticalScrollIndicator = false
     }
     
     init(frame: CGRect, filters: [Filter<T>]) {

--- a/bm-persona/Drawer/DrawerViewController.swift
+++ b/bm-persona/Drawer/DrawerViewController.swift
@@ -18,12 +18,11 @@ enum DrawerState {
 class DrawerViewController: UIViewController {
     var delegate: DrawerViewDelegate!
     var state: DrawerState = .collapsed
-    
     var bInitialized: Bool = false
+    var heightOffset: CGFloat?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         // Do any additional setup after loading the view.
     }
     
@@ -38,7 +37,9 @@ class DrawerViewController: UIViewController {
     func setupBackgroundView() {
         let backgroundView = UIView()
         backgroundView.backgroundColor = Color.modalBackground
-        backgroundView.layer.cornerRadius = 10
+        
+        backgroundView.layer.cornerRadius = 50
+        backgroundView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
         backgroundView.clipsToBounds = true
         
         let barView = UIView(frame: CGRect(x: self.view.frame.width / 2 - self.view.frame.width / 30, y: 7, width: self.view.frame.width / 15, height: 5))
@@ -47,14 +48,13 @@ class DrawerViewController: UIViewController {
         barView.layer.cornerRadius = barView.frame.height / 2
         barView.clipsToBounds = true
         backgroundView.addSubview(barView)
-
         
         backgroundView.translatesAutoresizingMaskIntoConstraints = false
         self.view = backgroundView
         
         let tabBarViewController = TabBarViewController()
         self.add(child: tabBarViewController)
-        tabBarViewController.view.frame = self.view.bounds
+        tabBarViewController.view.frame = self.view.bounds.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: heightOffset ?? 0, right: 0))
         tabBarViewController.view.frame.origin.y = barView.frame.maxY + 16
         tabBarViewController.view.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
     }

--- a/bm-persona/Drawer/DrawerViewController.swift
+++ b/bm-persona/Drawer/DrawerViewController.swift
@@ -54,7 +54,7 @@ class DrawerViewController: UIViewController {
         
         let tabBarViewController = TabBarViewController()
         self.add(child: tabBarViewController)
-        tabBarViewController.view.frame = self.view.bounds.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: heightOffset ?? 0, right: 0))
+        tabBarViewController.view.frame = self.view.bounds.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: (heightOffset ?? 0) + 20, right: 0))
         tabBarViewController.view.frame.origin.y = barView.frame.maxY + 16
         tabBarViewController.view.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
     }

--- a/bm-persona/Fitness/FitnessViewController.swift
+++ b/bm-persona/Fitness/FitnessViewController.swift
@@ -146,6 +146,7 @@ extension FitnessViewController: UITableViewDelegate, UITableViewDataSource {
             }
             
             if gym.image == nil {
+                cell.cellImage.image = UIImage(named: "DoeGlade")
                 DispatchQueue.global().async {
                     if gym.imageURL == nil {
                         return
@@ -153,8 +154,10 @@ extension FitnessViewController: UITableViewDelegate, UITableViewDataSource {
                     guard let imageData = try? Data(contentsOf: gym.imageURL!) else { return }
                     let image = UIImage(data: imageData)
                     DispatchQueue.main.async {
-                        cell.cellImage.image = image
                         gym.image = image
+                        if tableView.visibleCells.contains(cell) {
+                            cell.cellImage.image = image
+                        }
                     }
                 }
             } else {

--- a/bm-persona/Fitness/FitnessViewController.swift
+++ b/bm-persona/Fitness/FitnessViewController.swift
@@ -181,6 +181,7 @@ extension FitnessViewController {
         view.addSubview(scrollView)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.setConstraintsToView(top: view, bottom: view, left: view, right: view)
+        scrollView.showsVerticalScrollIndicator = false
         
         content = UIView()
         scrollView.addSubview(content)

--- a/bm-persona/Libraries/LibraryViewController.swift
+++ b/bm-persona/Libraries/LibraryViewController.swift
@@ -29,15 +29,6 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
         return img
     }()
     
-    let filterImage:UIImageView = {
-        let img = UIImageView()
-        img.contentMode = .scaleAspectFit
-        img.image = UIImage(named: "Filter")
-        img.translatesAutoresizingMaskIntoConstraints = false
-        img.clipsToBounds = true
-        return img
-    }()
-    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
@@ -100,16 +91,9 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
         bookImage.heightAnchor.constraint(equalToConstant: 26).isActive = true
         bookImage.widthAnchor.constraint(equalToConstant: 26).isActive = true
         
-        card.addSubview(filterImage)
-        filterImage.centerYAnchor.constraint(equalTo: studyLabel.centerYAnchor).isActive = true
-        filterImage.rightAnchor.constraint(equalTo: card.layoutMarginsGuide.rightAnchor).isActive
-            = true
-        filterImage.heightAnchor.constraint(equalToConstant: 22).isActive = true
-        filterImage.widthAnchor.constraint(equalToConstant: 22).isActive = true
-        
         studyLabel.translatesAutoresizingMaskIntoConstraints = false
         studyLabel.leftAnchor.constraint(equalTo: bookImage.rightAnchor, constant: 15).isActive = true
-        studyLabel.rightAnchor.constraint(equalTo: filterImage.leftAnchor, constant: -15).isActive = true
+        studyLabel.rightAnchor.constraint(equalTo: card.layoutMarginsGuide.rightAnchor).isActive = true
         studyLabel.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor).isActive = true
         
         setupFilterTableView()
@@ -172,6 +156,7 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
             }
             
             if lib.image == nil {
+                cell.cellImage.image = UIImage(named: "DoeGlade")
                 DispatchQueue.global().async {
                     if lib.imageURL == nil {
                         return
@@ -179,8 +164,10 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
                     guard let imageData = try? Data(contentsOf: lib.imageURL!) else { return }
                     let image = UIImage(data: imageData)
                     DispatchQueue.main.async {
-                        cell.cellImage.image = image
                         lib.image = image
+                        if tableView.visibleCells.contains(cell) {
+                            cell.cellImage.image = image
+                        }
                     }
                 }
             } else {
@@ -190,14 +177,6 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
             return cell
         }
         return UITableViewCell()
-    }
-    
-    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        // this will turn on `masksToBounds` just before showing the cell
-        cell.contentView.layer.masksToBounds = true
-        //to prevent laggy scrolling
-        let radius = cell.contentView.layer.cornerRadius
-        cell.layer.shadowPath = UIBezierPath(roundedRect: cell.bounds, cornerRadius: radius).cgPath
     }
     
 }

--- a/bm-persona/MainContainerViewController.swift
+++ b/bm-persona/MainContainerViewController.swift
@@ -28,11 +28,9 @@ class MainContainerViewController: UIViewController {
         super.viewDidLoad()
         add(child: mapViewController)
         add(child: drawerViewController)
-        
         drawerViewController.delegate = self
         mapViewController.view.frame = self.view.frame
         mapViewController.drawerContainer = self
-        
         drawerViewController.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             drawerViewController.view.heightAnchor.constraint(equalTo: self.view.heightAnchor),
@@ -47,6 +45,7 @@ class MainContainerViewController: UIViewController {
         drawerStatePositions[.collapsed] = self.view.frame.maxY * 0.9 + (self.view.frame.maxY / 2)
         drawerStatePositions[.middle] = self.view.frame.midY * 1.1 + (self.view.frame.maxY / 2)
         drawerStatePositions[.full] = self.view.safeAreaInsets.top + (self.view.frame.maxY / 2)
+        drawerViewController.heightOffset = 2 * self.view.safeAreaInsets.top
         self.initialDrawerCenter = drawerViewController.view.center
         moveDrawer(to: drawerViewController.state, duration: 0)
     }

--- a/bm-persona/MainContainerViewController.swift
+++ b/bm-persona/MainContainerViewController.swift
@@ -45,7 +45,7 @@ class MainContainerViewController: UIViewController {
         drawerStatePositions[.collapsed] = self.view.frame.maxY * 0.9 + (self.view.frame.maxY / 2)
         drawerStatePositions[.middle] = self.view.frame.midY * 1.1 + (self.view.frame.maxY / 2)
         drawerStatePositions[.full] = self.view.safeAreaInsets.top + (self.view.frame.maxY / 2)
-        drawerViewController.heightOffset = 2 * self.view.safeAreaInsets.top
+        drawerViewController.heightOffset = self.view.safeAreaInsets.top
         self.initialDrawerCenter = drawerViewController.view.center
         moveDrawer(to: drawerViewController.state, duration: 0)
     }


### PR DESCRIPTION
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-03 at 20 23 16](https://user-images.githubusercontent.com/20230668/78417656-1fd36980-75e9-11ea-9498-3311b199295f.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-04 at 01 28 25](https://user-images.githubusercontent.com/20230668/78422377-a43ae200-7613-11ea-9b7c-3539c0a512c3.png)


FilterTableView:
- Removed scrolling indicator

Library and Fitness ViewControllers:
- Used DoeGlade image as placeholder image
- Don't set cell image when cell is off-screen
- Removed filter icon for Library

Drawer:
- Inset contents of drawer so the bottom isn't cut off
- Updated corner radius
