### PR TITLE
Hotfix: Gym Class selection

### DIFF
--- a/bm-persona/Fitness/FitnessViewController.swift
+++ b/bm-persona/Fitness/FitnessViewController.swift
@@ -210,6 +210,7 @@ extension FitnessViewController {
         scheduleButton.rightAnchor.constraint(equalTo: card.layoutMarginsGuide.rightAnchor).isActive = true
         
         classesTable = UITableView()
+        classesTable.allowsSelection = false
         classesTable.separatorStyle = .none
         classesTable.showsVerticalScrollIndicator = false
         classesTable.rowHeight = EventTableViewCell.kCellHeight


### PR DESCRIPTION
Previously, gym classes in the 'Today' tableview were unable to be deselected.
- Disable selection on 'Today' gym classes