### PR TITLE
Hotfix: Gym Refreshing

### DIFF
--- a/bm-persona/Data/SortingFunctions.swift
+++ b/bm-persona/Data/SortingFunctions.swift
@@ -20,7 +20,11 @@ class SortingFunctions {
         }
         let d1 = loc1.getDistanceToUser(userLoc: currLocation!)
         let d2 = loc2.getDistanceToUser(userLoc: currLocation!)
-        if d2.isNaN {
+        if d1 == d2 || d1.isNaN && d2.isNaN,
+            let loc1 = loc1 as? SearchItem,
+            let loc2 = loc2 as? SearchItem {
+            return sortAlph(loc1: loc1, loc2: loc2)
+        } else if d2.isNaN {
             return true
         } else if d1.isNaN {
             return false


### PR DESCRIPTION
### To Reproduce Issue:
Run the app on a physical device in Release mode, with "Debug executable" turned off.

### Description
`locationManager(_:didUpdateLocations:)` in `FitnessViewController` (and other VCs) re-sorts and refreshes the data. Since Gym location data in Firebase are currently strings, sorting by closeness yields many equivalent `NaN` values. Re-sorting is thus not guaranteed to yield the same ordering.

Fixes the issue by breaking ties alphabetically.