### PR TITLE
Location Manager + Detail Consolidation

### DIFF
--- a/bm-persona.xcodeproj/project.pbxproj
+++ b/bm-persona.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01BC8EB024E8C3E3005B4969 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BC8EAF24E8C3E3005B4969 /* DetailView.swift */; };
+		01BC8EB224E8D920005B4969 /* IconPairView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BC8EB124E8D920005B4969 /* IconPairView.swift */; };
+		01FA50F124E8B33100DCC490 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA50F024E8B33100DCC490 /* LocationManager.swift */; };
+		01FA50F324E8BA5400DCC490 /* LocationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA50F224E8BA5400DCC490 /* LocationDetailView.swift */; };
 		130FA59E243B1243005DC752 /* DiningRestriction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130FA59D243B1243005DC752 /* DiningRestriction.swift */; };
 		130FA59F243B12B3005DC752 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553EF6AB2404E2C600D2955E /* Resource.swift */; };
 		13135BB22412442C0056B169 /* FilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B39AB323E777AC0039FBA2 /* FilterView.swift */; };
@@ -118,6 +122,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		01BC8EAF24E8C3E3005B4969 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		01BC8EB124E8D920005B4969 /* IconPairView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconPairView.swift; path = "bm-persona/Common/IconPairView.swift"; sourceTree = SOURCE_ROOT; };
+		01FA50F024E8B33100DCC490 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		01FA50F224E8BA5400DCC490 /* LocationDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDetailView.swift; sourceTree = "<group>"; };
 		130FA59D243B1243005DC752 /* DiningRestriction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiningRestriction.swift; sourceTree = "<group>"; };
 		132087AE23F3B05D00AE273C /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
 		1336A319241C3FD300949F32 /* GymClassDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymClassDataSource.swift; sourceTree = "<group>"; };
@@ -370,6 +378,7 @@
 				1396012E23865E2E005E4788 /* CollectionView */,
 				1396013123865E2E005E4788 /* CardView.swift */,
 				1396013223865E2E005E4788 /* TagView.swift */,
+				01BC8EB124E8D920005B4969 /* IconPairView.swift */,
 				554CB99F23F3A83F00BB1715 /* EventTableViewCell.swift */,
 				55C6936A240E143500400B60 /* ResourceTableViewCell.swift */,
 				5516088724393F3F00B1E55B /* MissingDataView.swift */,
@@ -461,6 +470,7 @@
 				13B8E95724256E4F00E7FCBF /* ItemProtocols */,
 				13EA64CF2399D50C00FD8E13 /* DataManager.swift */,
 				13B39A8C23E689BC0039FBA2 /* DataSource.swift */,
+				01FA50F024E8B33100DCC490 /* LocationManager.swift */,
 				29EE163E241C4E310041482E /* SortingFunctions.swift */,
 			);
 			path = Data;
@@ -469,6 +479,8 @@
 		2913595524B135B600DE9AD6 /* DetailView */ = {
 			isa = PBXGroup;
 			children = (
+				01BC8EAF24E8C3E3005B4969 /* DetailView.swift */,
+				01FA50F224E8BA5400DCC490 /* LocationDetailView.swift */,
 				29345E2624A7E76300859A88 /* OverviewCardView.swift */,
 				2913595824B13DF200DE9AD6 /* OpenTimesCardView.swift */,
 			);
@@ -789,6 +801,7 @@
 			files = (
 				130FA59F243B12B3005DC752 /* Resource.swift in Sources */,
 				13B8E9592425819D00E7FCBF /* ResourceDataSource.swift in Sources */,
+				01FA50F324E8BA5400DCC490 /* LocationDetailView.swift in Sources */,
 				29CB28092404DD53009A2CFB /* LibraryViewController.swift in Sources */,
 				55AF44292453A4EC00F13232 /* CafeDataSource.swift in Sources */,
 				306A550023614C0000D59A7F /* MainContainerViewController.swift in Sources */,
@@ -819,6 +832,7 @@
 				133864AE2404E858001F9048 /* CalendarEntry.swift in Sources */,
 				29B3D78824539FF3006762E5 /* MainDrawerViewController.swift in Sources */,
 				13491DBC242098B30033F9AB /* AtomicDictionary.swift in Sources */,
+				01BC8EB024E8C3E3005B4969 /* DetailView.swift in Sources */,
 				13580AFA243934BF00D309AA /* GymClassesController.swift in Sources */,
 				1396013423865E2E005E4788 /* CardCollectionViewCell.swift in Sources */,
 				55DCF79D237243F5001B01B8 /* RippleLayer.swift in Sources */,
@@ -850,6 +864,7 @@
 				297678892426D2C500FDD1EB /* SearchDrawerViewController.swift in Sources */,
 				29CB280A2404DD71009A2CFB /* FilterTableViewCell.swift in Sources */,
 				55DCF79623723CF2001B01B8 /* UIView+Extensions.swift in Sources */,
+				01BC8EB224E8D920005B4969 /* IconPairView.swift in Sources */,
 				306A54EA23613E3A00D59A7F /* AppDelegate.swift in Sources */,
 				1336A31C241C400800949F32 /* GymClass.swift in Sources */,
 				559A7B6B2373DCBA004EA501 /* SearchResultsView.swift in Sources */,
@@ -867,6 +882,7 @@
 				1396013323865E2E005E4788 /* CardCollectionView.swift in Sources */,
 				13B39A9A23E6A33C0039FBA2 /* LibraryDataSource.swift in Sources */,
 				306A54EC23613E3A00D59A7F /* SceneDelegate.swift in Sources */,
+				01FA50F124E8B33100DCC490 /* LocationManager.swift in Sources */,
 				29345E2724A7E76300859A88 /* OverviewCardView.swift in Sources */,
 				55AF442D2453ACE600F13232 /* DiningLocation.swift in Sources */,
 				1336A329241DA56100949F32 /* DiningHallDataSource.swift in Sources */,

--- a/bm-persona/AppDelegate.swift
+++ b/bm-persona/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         FirebaseApp.configure()
         DataManager.shared.fetchAll()
+        LocationManager.shared.requestLocation()
         return true
     }
 

--- a/bm-persona/Common/DetailView/DetailView.swift
+++ b/bm-persona/Common/DetailView/DetailView.swift
@@ -1,0 +1,33 @@
+//
+//  DetailView.swift
+//  bm-persona
+//
+//  Created by Kevin Hu on 8/15/20.
+//  Copyright © 2020 RJ Pimentel. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// Delegate for a `DetailView`.
+protocol DetailViewDelegate: NSObject {
+    /// Called when a `DetailView` updates its contents.
+    func detailsUpdated(for view: UIView)
+}
+
+/// A view presenting information for a single protocol.
+protocol DetailView: UIView {
+    /// The protocol this detail view presents information for.
+    associatedtype Item
+
+    /// The `DetailViewDelegate` for this detail view.
+    ///
+    /// This property should be `weak` to prevent retain cycles.
+    var delegate: DetailViewDelegate? { get set }
+
+    /// Indicates when crucial data is missing and the view should not be shown.
+    var missingData: Bool { get }
+
+    /// Configures the view with relevant info from `item`.
+    func configure(for item: Item)
+}

--- a/bm-persona/Common/DetailView/LocationDetailView.swift
+++ b/bm-persona/Common/DetailView/LocationDetailView.swift
@@ -1,0 +1,77 @@
+//
+//  LocationDetailView.swift
+//  bm-persona
+//
+//  Created by Kevin Hu on 4/24/20.
+//  Copyright © 2020 RJ Pimentel. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// The standard view for displaying the distance between the user and an item conforming to `HasLocation`.
+class LocationDetailView: IconPairView, DetailView {
+
+    typealias Item = HasLocation
+
+    private var icon: UIImageView!
+    private var label: UILabel!
+
+    /// The item configuring this view.
+    private var item: HasLocation?
+
+    weak var delegate: DetailViewDelegate?
+
+    var missingData: Bool {
+        guard let item = item else { return true }
+        return item.distanceToUser == nil
+    }
+
+    func configure(for item: HasLocation) {
+        self.item = item
+        label.text = "Unknonw"
+        if let distance = item.distanceToUser {
+            label.text = String(format: "%.1f mi", distance)
+        }
+        delegate?.detailsUpdated(for: self)
+    }
+
+    init() {
+        icon = UIImageView()
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.image = UIImage(named: "Walk")
+        icon.contentMode = .scaleAspectFit
+        icon.clipsToBounds = true
+
+        label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = Font.light(12)
+        label.textColor = Color.blackText
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.75
+        label.numberOfLines = 1
+
+        super.init(icon: icon, iconHeight: 16, iconWidth: 16, attachedView: label)
+
+        // Register for location updates
+        LocationManager.notificationCenter.addObserver(
+            self,
+            selector: #selector(locationUpdated(_:)),
+            name: .locationUpdated,
+            object: nil
+        )
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Location Manager Notification
+
+extension LocationDetailView {
+    @objc func locationUpdated(_ notification: Notification) {
+        guard let item = item else { return }
+        configure(for: item)
+    }
+}

--- a/bm-persona/Common/DetailView/LocationDetailView.swift
+++ b/bm-persona/Common/DetailView/LocationDetailView.swift
@@ -29,7 +29,7 @@ class LocationDetailView: IconPairView, DetailView {
 
     func configure(for item: HasLocation) {
         self.item = item
-        label.text = "Unknonw"
+        label.text = "Unknown"
         if let distance = item.distanceToUser {
             label.text = String(format: "%.1f mi", distance)
         }

--- a/bm-persona/Common/DetailView/OverviewCardView.swift
+++ b/bm-persona/Common/DetailView/OverviewCardView.swift
@@ -24,21 +24,17 @@ enum OverviewElements {
 
 class OverviewCardView: CardView {
     var item: SearchItem!
-    var userLocation: CLLocation?
-    // tracks if the distance information is added to prevent adding multiple times when user location updates
-    var distanceViewAdded = false
     var addressView: UIView?
     // elements to exclude from the card even if they are available
     var excludedElements: [OverviewElements] = []
     
-    public init(item: SearchItem, excludedElements: [OverviewElements] = [], userLocation: CLLocation? = nil) {
+    public init(item: SearchItem, excludedElements: [OverviewElements] = []) {
         super.init(frame: CGRect.zero)
         self.isUserInteractionEnabled = true
         self.layoutMargins = kCardPadding
         self.translatesAutoresizingMaskIntoConstraints = false
         self.item = item
         self.excludedElements = excludedElements
-        self.userLocation = userLocation
         
         setUpStaticElements()
         setUpOptionalElements()
@@ -90,7 +86,7 @@ class OverviewCardView: CardView {
             } else {
                 addressLabel.text = longAddress
             }
-            addressView = UIView.iconPairView(icon: addressIcon, iconHeight: 16, attachedView: addressLabel)
+            addressView = IconPairView(icon: addressIcon, iconHeight: 16, attachedView: addressLabel)
             leftVerticalStack.addArrangedSubview(addressView!)
             addressView!.leftAnchor.constraint(equalTo: leftVerticalStack.leftAnchor).isActive = true
             addressView!.rightAnchor.constraint(equalTo: leftVerticalStack.rightAnchor).isActive = true
@@ -98,20 +94,24 @@ class OverviewCardView: CardView {
         
         if !excludedElements.contains(.phone), let itemWithPhone = item as? HasPhoneNumber, let phoneNumber = itemWithPhone.phoneNumber {
             phoneLabel.text = phoneNumber
-            secondRowHorizontalStack.addArrangedSubview(UIView.iconPairView(icon: phoneIcon, iconHeight: 16, attachedView: phoneLabel))
+            secondRowHorizontalStack.addArrangedSubview(IconPairView(icon: phoneIcon, iconHeight: 16, attachedView: phoneLabel))
         }
 
-        updateDistanceDisplay()
+        if !excludedElements.contains(.distance), let itemWithLocation = item as? HasLocation {
+            locationDetailView.delegate = self
+            locationDetailView.configure(for: itemWithLocation)
+            secondRowHorizontalStack.addArrangedSubview(locationDetailView)
+        }
 
         // if the row stack has any elements add it to the vertical stack, otherwise don't add it to prevent spacing issues
-        if secondRowHorizontalStack.arrangedSubviews.count > 0 {
+        if !secondRowHorizontalStack.emptyOrChildrenHidden {
             leftVerticalStack.addArrangedSubview(secondRowHorizontalStack)
             secondRowHorizontalStack.leftAnchor.constraint(equalTo: leftVerticalStack.leftAnchor).isActive = true
             secondRowHorizontalStack.rightAnchor.constraint(equalTo: leftVerticalStack.rightAnchor).isActive = true
         }
         
         if !excludedElements.contains(.openTimes), let itemWithOpenTimes = item as? HasOpenTimes, itemWithOpenTimes.weeklyHours != nil {
-            openTimesStack.addArrangedSubview(UIView.iconPairView(icon: clockIcon, iconHeight: 16, attachedView: openTimeLabel))
+            openTimesStack.addArrangedSubview(IconPairView(icon: clockIcon, iconHeight: 16, attachedView: openTimeLabel))
 
             let formatter = DateIntervalFormatter()
             formatter.dateStyle = .none
@@ -148,7 +148,7 @@ class OverviewCardView: CardView {
 
         if !excludedElements.contains(.occupancy), let itemWithOccupancy = item as? HasOccupancy, let status = itemWithOccupancy.getOccupancyStatus(date: Date()) {
             occupancyBadge.widthAnchor.constraint(equalToConstant: 50).isActive = true
-            let occupancyView = UIView.iconPairView(icon: chairImage, iconHeight: 16, iconWidth: 28, attachedView: occupancyBadge)
+            let occupancyView = IconPairView(icon: chairImage, iconHeight: 16, iconWidth: 28, attachedView: occupancyBadge)
             switch status {
             case OccupancyStatus.high:
                 occupancyBadge.text = "High"
@@ -181,30 +181,6 @@ class OverviewCardView: CardView {
             belowImageHorizontalStack.rightAnchor.constraint(equalTo: imageView.rightAnchor).isActive = true
             belowImageHorizontalStack.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: kViewMargin).isActive = true
             belowImageHorizontalStack.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -1 * kViewMargin).isActive = true
-        }
-    }
-    
-    public func updateLocation(userLocation: CLLocation) {
-        self.userLocation = userLocation
-        updateDistanceDisplay()
-    }
-    
-    private func updateDistanceDisplay() {
-        if !excludedElements.contains(.distance), let itemWithLocation = item as? HasLocation, let userLocation = self.userLocation {
-            let dist = itemWithLocation.getDistanceToUser(userLoc: userLocation)
-            distLabel.text = String(dist) + " mi"
-            if !distanceViewAdded, dist < type(of: itemWithLocation).invalidDistance {
-                secondRowHorizontalStack.addArrangedSubview(UIView.iconPairView(icon: distIcon, iconHeight: 16, attachedView: distLabel))
-                distanceViewAdded = true
-                // if the row stack wasn't originally added (no phone and distance initially), add it under the address view or at the top if address view isn't added
-                if !leftVerticalStack.arrangedSubviews.contains(secondRowHorizontalStack) {
-                    if let addressView = self.addressView, let index = leftVerticalStack.arrangedSubviews.firstIndex(of: addressView) {
-                        leftVerticalStack.insertArrangedSubview(secondRowHorizontalStack, at: index + 1)
-                    } else {
-                        leftVerticalStack.insertArrangedSubview(secondRowHorizontalStack, at: 0)
-                    }
-                }
-            }
         }
     }
     
@@ -365,43 +341,26 @@ class OverviewCardView: CardView {
         return label
     }()
     
-    let distIcon: UIImageView = {
-        let image = UIImageView()
-        image.image = UIImage(named: "Walk")
-        image.translatesAutoresizingMaskIntoConstraints = false
-        image.contentMode = .scaleAspectFit
-        image.clipsToBounds = true
-        return image
-    }()
-    
-    let distLabel: UILabel =  {
-        let label = UILabel()
-        label.font = Font.light(12)
-        label.textColor = Color.blackText
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 0.75
-        label.numberOfLines = 1
-        return label
+    let locationDetailView: LocationDetailView = {
+        return LocationDetailView()
     }()
 }
 
-extension UIView {
-    // returns a view containing an icon next to another view, used for overview card and table cells
-    public static func iconPairView(icon: UIImageView, iconHeight: CGFloat, iconWidth: CGFloat? = nil, attachedView: UILabel) -> UIView {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(icon)
-        view.addSubview(attachedView)
-        icon.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-        icon.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
-        icon.widthAnchor.constraint(equalToConstant: iconWidth ?? iconHeight).isActive = true
-        icon.heightAnchor.constraint(equalToConstant: iconHeight).isActive = true
-        attachedView.leftAnchor.constraint(equalTo: icon.rightAnchor, constant: 5).isActive = true
-        attachedView.centerYAnchor.constraint(equalTo: icon.centerYAnchor).isActive = true
-        attachedView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
-        view.heightAnchor.constraint(greaterThanOrEqualTo: icon.heightAnchor).isActive = true
-        view.heightAnchor.constraint(greaterThanOrEqualTo: attachedView.heightAnchor).isActive = true
-        return view
+// MARK: - DetailView Delegate
+
+extension OverviewCardView: DetailViewDelegate {
+    func detailsUpdated(for view: UIView) {
+        if let locationDetailView = view as? LocationDetailView {
+            locationDetailView.isHidden = locationDetailView.missingData
+
+            // if the row stack wasn't originally added (no phone and distance initially), add it under the address view or at the top if address view isn't added
+            if !locationDetailView.isHidden && !leftVerticalStack.arrangedSubviews.contains(secondRowHorizontalStack) {
+                if let addressView = self.addressView, let index = leftVerticalStack.arrangedSubviews.firstIndex(of: addressView) {
+                    leftVerticalStack.insertArrangedSubview(secondRowHorizontalStack, at: index + 1)
+                } else {
+                    leftVerticalStack.insertArrangedSubview(secondRowHorizontalStack, at: 0)
+                }
+            }
+        }
     }
 }

--- a/bm-persona/Common/FilterTableView/FilterTableView.swift
+++ b/bm-persona/Common/FilterTableView/FilterTableView.swift
@@ -78,7 +78,7 @@ class FilterTableView<T>: UIView {
     }
     
     var workItem: DispatchWorkItem?
-    func update() {
+    @objc func update() {
         workItem?.cancel()
         let data = self.data
         workItem = Filter.apply(filters: filters, on: data, indices: filter.indexPathsForSelectedItems?.map { $0.row }, completion: {

--- a/bm-persona/Common/FilterTableView/FilterTableViewCell.swift
+++ b/bm-persona/Common/FilterTableView/FilterTableViewCell.swift
@@ -68,16 +68,14 @@ class FilterTableViewCell: UITableViewCell {
         distanceOccupancyStack.leftAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leftAnchor).isActive = true
     }
     
-    // sets the contents of the cell based on an item passed in, the user's current location, and a closure to call if there is no image available
-    func updateContents(item: SearchItem, location: CLLocation?, imageUpdate: () -> Void) {
+    // Sets the contents of the cell based on an item passed in and a closure to call if there is no image available
+    func updateContents(item: SearchItem, imageUpdate: () -> Void) {
         nameLabel.text = item.searchName
         distanceOccupancyStack.removeAllArrangedSubviews()
-        if let itemWithLocation = item as? HasLocation, let userLocation = location {
-            let distance = itemWithLocation.getDistanceToUser(userLoc: userLocation)
-            if distance < type(of: itemWithLocation).invalidDistance {
-                distLabel.text = "\(distance) mi"
-                distanceOccupancyStack.addArrangedSubview(UIView.iconPairView(icon: distImage, iconHeight: 16, attachedView: distLabel))
-            }
+        if let itemWithLocation = item as? HasLocation {
+            locationDetailView.delegate = self
+            locationDetailView.configure(for: itemWithLocation)
+            distanceOccupancyStack.addArrangedSubview(locationDetailView)
         }
         self.recLabel.text = "Recommended"
         
@@ -93,7 +91,7 @@ class FilterTableViewCell: UITableViewCell {
                 occupancyBadge.text = "Low"
                 occupancyBadge.backgroundColor = Color.lowCapacityTag
             }
-            distanceOccupancyStack.addArrangedSubview(UIView.iconPairView(icon: chairImage, iconHeight: 16, iconWidth: 28, attachedView: occupancyBadge))
+            distanceOccupancyStack.addArrangedSubview(IconPairView(icon: chairImage, iconHeight: 16, iconWidth: 28, attachedView: occupancyBadge))
         }
         
         cellImage.image = UIImage(named: "DoeGlade")
@@ -149,23 +147,9 @@ class FilterTableViewCell: UITableViewCell {
         stack.spacing = 30
         return stack
     }()
-    
-    let distImage:UIImageView = {
-        let img = UIImageView()
-        img.contentMode = .scaleAspectFit
-        img.image = UIImage(named: "Walk")
-        img.translatesAutoresizingMaskIntoConstraints = false
-        img.clipsToBounds = true
-        return img
-    }()
-    
-    let distLabel:UILabel = {
-        let label = UILabel()
-        label.adjustsFontSizeToFitWidth = true
-        label.font = Font.light(12)
-        label.textColor = Color.blackText
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
+
+    let locationDetailView: LocationDetailView = {
+        return LocationDetailView()
     }()
     
     let chairImage:UIImageView = {
@@ -177,11 +161,19 @@ class FilterTableViewCell: UITableViewCell {
         return img
     }()
     
-    let occupancyBadge:TagView = {
+    let occupancyBadge: TagView = {
         let occ = TagView(origin: .zero, text: "", color: .clear)
         occ.translatesAutoresizingMaskIntoConstraints = false
         return occ
     }()
-    
-    
+}
+
+// MARK: - DetailViewDelegate
+
+extension FilterTableViewCell: DetailViewDelegate {
+    func detailsUpdated(for view: UIView) {
+        if let locationDetailView = view as? LocationDetailView {
+            locationDetailView.isHidden = locationDetailView.missingData
+        }
+    }
 }

--- a/bm-persona/Common/IconPairView.swift
+++ b/bm-persona/Common/IconPairView.swift
@@ -1,0 +1,37 @@
+//
+//  IconPairView.swift
+//  bm-persona
+//
+//  Created by Kevin Hu on 8/15/20.
+//  Copyright © 2020 RJ Pimentel. All rights reserved.
+//
+
+import UIKit
+
+/// A view containing an icon next to a label.
+class IconPairView: UIView {
+
+    init(icon: UIImageView, iconHeight: CGFloat, iconWidth: CGFloat? = nil, attachedView: UILabel) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(icon)
+        addSubview(attachedView)
+
+        icon.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
+        icon.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        icon.widthAnchor.constraint(equalToConstant: iconWidth ?? iconHeight).isActive = true
+        icon.heightAnchor.constraint(equalToConstant: iconHeight).isActive = true
+
+        attachedView.leftAnchor.constraint(equalTo: icon.rightAnchor, constant: 5).isActive = true
+        attachedView.centerYAnchor.constraint(equalTo: icon.centerYAnchor).isActive = true
+        attachedView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
+
+        heightAnchor.constraint(greaterThanOrEqualTo: icon.heightAnchor).isActive = true
+        heightAnchor.constraint(greaterThanOrEqualTo: attachedView.heightAnchor).isActive = true
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/bm-persona/Data/ItemProtocols/HasLocation.swift
+++ b/bm-persona/Data/ItemProtocols/HasLocation.swift
@@ -10,24 +10,53 @@ import Foundation
 import MapKit
 
 protocol HasLocation {
-    
+
+    // MARK: Required
+
+    /// The latitude of the conforming object.
     var latitude: Double? { get }
+
+    /// The longitude of the conforming object.
     var longitude: Double? { get }
+
+    /// The address of the conforming object.
     var address: String? { get }
-    func getDistanceToUser(userLoc: CLLocation?) -> Double
-    static var nearbyDistance: Double { get }
-    static var invalidDistance: Double { get }
+
+    // MARK: Static Methods
+
+    /// Returns a comparator used to compare two items by their distance to the user.
+    static func locationComparator() -> ((HasLocation, HasLocation) -> Bool)
+
+    /// Returns a closure that filters items by their distance to the user.
+    static func locationFilter(by maxDistance: Double) -> ((HasLocation) -> Bool)
     
 }
 
 extension HasLocation {
-    
-    func getDistanceToUser(userLoc: CLLocation?) -> Double {
-        if let lat = latitude, let lon = longitude, userLoc != nil && lat != Double.nan && lon != Double.nan {
+
+    /// Returns the distance to the user in miles if possible, otherwise `nil`.
+    var distanceToUser: Double? {
+        guard let location = LocationManager.shared.userLocation else { return nil }
+        if let lat = latitude, let lon = longitude, lat != Double.nan, lon != Double.nan {
             let itemLocation = CLLocation(latitude: lat, longitude: lon)
-            let distance = round(userLoc!.distance(from: itemLocation) / 1600.0 * 10) / 10
-            return distance
+            let meters = location.distance(from: itemLocation)
+            let measurement = Measurement(value: meters, unit: UnitLength.meters)
+            let miles = measurement.converted(to: UnitLength.miles).value
+            return miles
         }
-        return Double.nan
+        return nil
+    }
+
+    static func locationComparator() -> ((HasLocation, HasLocation) -> Bool) {
+        return SortingFunctions.sortClose(loc1:loc2:)
+    }
+
+    static func locationFilter(by maxDistance: Double) -> ((HasLocation) -> Bool) {
+        return { item in
+            if let distance = item.distanceToUser, distance <= maxDistance {
+                return true
+            }
+            return false
+        }
     }
 }

--- a/bm-persona/Data/LocationManager.swift
+++ b/bm-persona/Data/LocationManager.swift
@@ -1,0 +1,82 @@
+//
+//  LocationManager.swift
+//  bm-persona
+//
+//  Created by Kevin Hu on 4/17/20.
+//  Copyright © 2020 RJ Pimentel. All rights reserved.
+//
+
+import Foundation
+import MapKit
+
+// MARK: - Location Manager Notifications
+
+extension Notification.Name {
+    /// Notification sent whenever the user's location is fetched or changes.
+    static var locationUpdated: Notification.Name {
+        return .init(rawValue: "LocationManager.locationUpdated")
+    }
+}
+
+// MARK: - Location Manager
+
+/// Wrapper for `CLLocationManager`. Intended to work as a singleton location manager.
+/// Sends updated to observers using `NotificationCenter`.
+class LocationManager: NSObject {
+
+    /// Singleton instance of a `LocationManager`.
+    static let shared = LocationManager()
+
+    /// The notification center used to send location updates.
+    static var notificationCenter = NotificationCenter.default
+    private var _locationManager: CLLocationManager!
+
+    /// The most-updated location for the current user. `nil` if no location data has ever been recieved.
+    open var userLocation: CLLocation?
+
+    override init() {
+        super.init()
+
+        _locationManager = CLLocationManager()
+        _locationManager.delegate = self
+        _locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        _locationManager.requestWhenInUseAuthorization()
+        userLocation = _locationManager.location
+    }
+
+    deinit {
+        _locationManager.stopUpdatingLocation()
+    }
+
+    /// Starts collecting the user's location.
+    func requestLocation() {
+        _locationManager.startUpdatingLocation()
+    }
+}
+
+// MARK: CLLocationManagerDelegate
+
+extension LocationManager: CLLocationManagerDelegate {
+
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        if status == .authorizedWhenInUse {
+            manager.startUpdatingLocation()
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        if let location = locations.last {
+            userLocation = location
+            LocationManager.notificationCenter.post(name: .locationUpdated, object: location)
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        if let clErr = error as? CLError {
+            if clErr.code == CLError.denied {
+                manager.stopUpdatingLocation()
+            }
+        }
+        print("Location Error: ", error)
+    }
+}

--- a/bm-persona/Data/SortingFunctions.swift
+++ b/bm-persona/Data/SortingFunctions.swift
@@ -10,26 +10,19 @@ import Foundation
 import MapKit
 
 class SortingFunctions {
-    static func sortClose(loc1: HasLocation, loc2: HasLocation, location: CLLocation?, locationManager: CLLocationManager) -> Bool {
-        var currLocation = location
-        if location == nil {
-            currLocation = locationManager.location
-            if currLocation == nil {
-                return true
-            }
-        }
-        let d1 = loc1.getDistanceToUser(userLoc: currLocation!)
-        let d2 = loc2.getDistanceToUser(userLoc: currLocation!)
-        if d1 == d2 || d1.isNaN && d2.isNaN,
+    static func sortClose(loc1: HasLocation, loc2: HasLocation) -> Bool {
+        let d1 = loc1.distanceToUser
+        let d2 = loc2.distanceToUser
+        if d1 == d2,
             let loc1 = loc1 as? SearchItem,
             let loc2 = loc2 as? SearchItem {
             return sortAlph(loc1: loc1, loc2: loc2)
-        } else if d2.isNaN {
+        } else if d2 == nil {
             return true
-        } else if d1.isNaN {
+        } else if d1 == nil {
             return false
         } else {
-            return d1 < d2
+            return d1! < d2!
         }
     }
     

--- a/bm-persona/Dining/DiningDataSource/DiningLocation.swift
+++ b/bm-persona/Dining/DiningDataSource/DiningLocation.swift
@@ -13,7 +13,6 @@ class DiningLocation: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasI
     var icon: UIImage?
     
     static var nearbyDistance: Double = 10
-    static var invalidDistance: Double = 100
     
     var isFavorited: Bool = false
     var searchName: String {

--- a/bm-persona/Dining/DiningDetailViewController.swift
+++ b/bm-persona/Dining/DiningDetailViewController.swift
@@ -15,8 +15,6 @@ fileprivate let kViewMargin: CGFloat = 16
 class DiningDetailViewController: SearchDrawerViewController {
     
     var diningHall: DiningLocation!
-    var locationManager = CLLocationManager()
-    var location: CLLocation?
     var overviewCard: OverviewCardView!
     var control: TabBarControl?
     var meals: MealMap!
@@ -28,16 +26,11 @@ class DiningDetailViewController: SearchDrawerViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        locationManager.delegate = self
+
         setUpOverviewCard()
         setUpMenuControl()
         setUpMenu()
         view.layoutSubviews()
-        
-        if CLLocationManager.locationServicesEnabled() {
-            locationManager.requestLocation()
-        }
     }
     
     override func viewDidLayoutSubviews() {
@@ -49,7 +42,7 @@ class DiningDetailViewController: SearchDrawerViewController {
 
 extension DiningDetailViewController {
     func setUpOverviewCard() {
-        overviewCard = OverviewCardView(item: diningHall, userLocation: location)
+        overviewCard = OverviewCardView(item: diningHall)
         view.addSubview(overviewCard)
         overviewCard.topAnchor.constraint(equalTo: barView.bottomAnchor, constant: kViewMargin).isActive = true
         overviewCard.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
@@ -136,19 +129,6 @@ extension DiningDetailViewController {
                     return restr.known != nil && restr.known == restriction
                 })})
         }
-    }
-}
-
-extension DiningDetailViewController : CLLocationManagerDelegate {
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        let userLocation : CLLocation = locations[0] as CLLocation
-        DispatchQueue.main.async {
-            self.overviewCard.updateLocation(userLocation: userLocation)
-        }
-    }
-    
-    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        print(error)
     }
 }
 

--- a/bm-persona/Fitness/Fitness+Controllers/GymsController.swift
+++ b/bm-persona/Fitness/Fitness+Controllers/GymsController.swift
@@ -29,7 +29,7 @@ extension GymsController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if let cell = tableView.dequeueReusableCell(withIdentifier: FilterTableViewCell.kCellIdentifier, for: indexPath) as? FilterTableViewCell {
             let gym: Gym = vc.filterTableView.filteredData[indexPath.row]
-            cell.updateContents(item: gym, location: vc.location, imageUpdate: {
+            cell.updateContents(item: gym, imageUpdate: {
                 DispatchQueue.global().async {
                     guard let imageURL = gym.imageURL, let imageData = try? Data(contentsOf: imageURL) else { return }
                     let image = UIImage(data: imageData)

--- a/bm-persona/Fitness/GymDataSource/Gym.swift
+++ b/bm-persona/Fitness/GymDataSource/Gym.swift
@@ -12,7 +12,6 @@ import UIKit
 class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOpenTimes, HasOccupancy {
     
     static var nearbyDistance: Double = 10
-    static var invalidDistance: Double = 100
     var icon: UIImage?
     
     var searchName: String {

--- a/bm-persona/Libraries/LibraryDataSource/Library.swift
+++ b/bm-persona/Libraries/LibraryDataSource/Library.swift
@@ -12,7 +12,6 @@ import MapKit
 class Library: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOpenTimes, HasOccupancy {
     
     static var nearbyDistance: Double = 10
-    static var invalidDistance: Double = 100
     
     var searchName: String {
         return name

--- a/bm-persona/Libraries/LibraryDetailViewController.swift
+++ b/bm-persona/Libraries/LibraryDetailViewController.swift
@@ -14,14 +14,12 @@ fileprivate let kViewMargin: CGFloat = 16
 
 class LibraryDetailViewController: SearchDrawerViewController {
     var library : Library!
-    var locationManager = CLLocationManager()
     var overviewCard: OverviewCardView!
     var openTimesCard: OpenTimesCardView?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        locationManager.delegate = self
+
         setUpScrollView()
         setUpOverviewCard()
         setUpOpenTimesCard()
@@ -30,10 +28,6 @@ class LibraryDetailViewController: SearchDrawerViewController {
         // in order to set the cutoff correctly
         view.layoutSubviews()
         scrollView.layoutSubviews()
-        
-        if CLLocationManager.locationServicesEnabled() {
-            locationManager.requestLocation()
-        }
     }
     
     override func viewDidLayoutSubviews() {
@@ -86,7 +80,7 @@ class LibraryDetailViewController: SearchDrawerViewController {
 
 extension LibraryDetailViewController {
     func setUpOverviewCard() {
-        overviewCard = OverviewCardView(item: library, excludedElements: [.openTimes, .occupancy], userLocation: locationManager.location)
+        overviewCard = OverviewCardView(item: library, excludedElements: [.openTimes, .occupancy])
         scrollContent.addSubview(overviewCard)
         overviewCard.topAnchor.constraint(equalTo: scrollContent.topAnchor).isActive = true
         overviewCard.leftAnchor.constraint(equalTo: scrollContent.leftAnchor).isActive = true
@@ -135,18 +129,5 @@ extension LibraryDetailViewController {
         scrollView.addSubview(scrollContent)
         scrollContent.widthAnchor.constraint(equalTo: scrollContainer.widthAnchor, constant: -1 * (scrollView.contentInset.left + scrollView.contentInset.right)).isActive = true
         scrollContent.centerXAnchor.constraint(equalTo: scrollContainer.centerXAnchor).isActive = true
-    }
-}
-    
-extension LibraryDetailViewController : CLLocationManagerDelegate {
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        let userLocation : CLLocation = locations[0] as CLLocation
-        DispatchQueue.main.async {
-            self.overviewCard.updateLocation(userLocation: userLocation)
-        }
-    }
-    
-    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        print(error)
     }
 }

--- a/bm-persona/Map/MapViewController.swift
+++ b/bm-persona/Map/MapViewController.swift
@@ -22,7 +22,6 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
     private var maskView: UIView!
     private var searchBar: SearchBarView!
     private var searchResultsView: SearchResultsView!
-    private var locationManager = CLLocationManager()
     
     // DrawerViewDelegate properties
     var drawerViewController: DrawerViewController?
@@ -77,8 +76,6 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
             self.mapMarkers = markers as? [[MapMarker]] ?? []
         }
         
-        requestLocation()
-        
         self.view.addSubViews([mapView, filterView, markerDetail, maskView, searchResultsView, searchBar])
         setupSubviews()
     }
@@ -120,13 +117,6 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
         filterView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
         filterView.contentInset = UIEdgeInsets(top: 0, left: view.layoutMargins.left,
                                                bottom: 0, right: view.layoutMargins.right)
-    }
-    
-    private func requestLocation() {
-        locationManager.delegate = self
-        locationManager.desiredAccuracy = kCLLocationAccuracyBest
-        locationManager.requestWhenInUseAuthorization()
-        locationManager.requestLocation()
     }
     
     private func showSearchResultsView(_ show: Bool) {
@@ -244,29 +234,6 @@ extension MapViewController: MapMarkerDetailViewDelegate {
         }
     }
     
-}
-
-
-// MARK: - CLLocationManagerDelegate
-
-extension MapViewController: CLLocationManagerDelegate {
-    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if status == .authorizedWhenInUse {
-            locationManager.requestLocation()
-        }
-    }
-
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        if let location = locations.first {
-            let span = MKCoordinateSpan.init(latitudeDelta: 0.05, longitudeDelta: 0.05)
-            let region = MKCoordinateRegion(center: location.coordinate, span: span)
-            mapView.setRegion(region, animated: true)
-        }
-    }
-
-    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        print("error: ", error)
-    }
 }
 
 // MARK: - SearchBarDelegate

--- a/bm-persona/Map/SearchResultCell.swift
+++ b/bm-persona/Map/SearchResultCell.swift
@@ -19,8 +19,6 @@ class SearchResultCell: MaterialTableViewCell {
     private var leftStack: UIStackView!
     private var rightStack: UIStackView!
     
-    private var locationManager: CLLocationManager = CLLocationManager()
-    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setCornerBorder(cornerRadius: 0.0)
@@ -73,7 +71,7 @@ class SearchResultCell: MaterialTableViewCell {
         subTitle.text = currentPlacemark.locationName // TODO: - fix
         
         guard
-            let userLoc = locationManager.location,
+            let userLoc = LocationManager.shared.userLocation,
             let placemarkLoc = currentPlacemark.location
         else {
             return

--- a/bm-persona/Resources/ResourcesDataSource/Resource.swift
+++ b/bm-persona/Resources/ResourcesDataSource/Resource.swift
@@ -13,7 +13,6 @@ class Resource: SearchItem, HasLocation, HasOpenTimes {
     var icon: UIImage?
     
     static var nearbyDistance: Double = 10
-    static var invalidDistance: Double = 100
     
     var searchName: String {
         return name

--- a/bm-persona/Utils/UIStackView+Extensions.swift
+++ b/bm-persona/Utils/UIStackView+Extensions.swift
@@ -10,6 +10,12 @@ import Foundation
 import UIKit
 
 extension UIStackView {
+
+    /// Returns `true` iff the stack view has no children or if all those children are hidden.
+    public var emptyOrChildrenHidden: Bool {
+        return arrangedSubviews.isEmpty || arrangedSubviews.allSatisfy { $0.isHidden }
+    }
+
     public func removeAllArrangedSubviews() {
         for view in arrangedSubviews {
             removeArrangedSubview(view)


### PR DESCRIPTION
Adds `LocationManager`, a simple wrapper for `CLLocationManager` that fetches updates to the user's location and notifies observers. Using a singleton instance, we can significantly simplify location requests throughout the app and clean up some code.
- Adds `LocationManager` and `Notification.Name.locationUpdated`, which is used to notify listeners about a new location update.
- Removes `CLLocationManager` instances in other classes
- Changes `HasLocation` to use the new manager
  - `getDistanceToUser(userLoc:)` > `distanceToUser`, an optional boolean
  - Removes the `invalidDistance` double from models
  - Adds `locationComparator` and `locationFilter`, since they are commonly used for models conforming to `HasLocation`

Also consolidated how distance information is presented into `LocationDetailView`, which is the same walking man icon + distance label currently used in table cells and the overview card.
- Added `DetailView` and `DetailViewDelegate`, protocols for displaying details regarding a single protocol
  - I feel like these are kinda unnecessary, but I think it might be helpful in the future if we also consolidate the views for things like occupancy, open/closed, etc.?

Other changes
- Moved `UIView.iconPairView` from `OverviewCardView` to `Common/IconPairView.swift`
- Added `emptyOrChildrenHidden` bool to `UIStackView`

Curious to hear what people think of these changes. It doesn't change anything visually / functionally in the app, but the goal is to reduce some of the repeated blocks.