### PR TITLE
TabBar Icon Vertical Positioning

### DIFF
--- a/bm-persona/Tab Bar/TabBarController.swift
+++ b/bm-persona/Tab Bar/TabBarController.swift
@@ -20,15 +20,12 @@ class TabBarController: UITabBarController, UITabBarControllerDelegate {
         
         let mapView = MainContainerViewController()
         mapView.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "Home"), tag: 0)
-        mapView.tabBarItem.imageInsets = UIEdgeInsets.init(top: 6, left: 0, bottom: -6, right: 0)
         
         let resourcesView = ResourcesViewController()
         resourcesView.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "Resources"), tag: 1)
-        resourcesView.tabBarItem.imageInsets = UIEdgeInsets.init(top: 6, left: 0, bottom: -6, right: 0)
         
         let calendarView = CalendarViewController()
         calendarView.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "Calendar"), tag: 2)
-        calendarView.tabBarItem.imageInsets = UIEdgeInsets.init(top: 6, left: 0, bottom: -6, right: 0)
         
         self.viewControllers = [mapView, resourcesView, calendarView]
     }


### PR DESCRIPTION
Previously, TabBar icons were not vertically centered on devices with small screens:
<img width="559" alt="Screen Shot 2020-08-29 at 4 32 28 PM" src="https://user-images.githubusercontent.com/41145903/91647915-ba5b9b80-ea15-11ea-80e5-d278f49ee48b.png">

These icons are inset 6px from their default positions. Removing the inset fixes the issue:
<img width="559" alt="Screen Shot 2020-08-29 at 4 32 53 PM" src="https://user-images.githubusercontent.com/41145903/91647934-f5f66580-ea15-11ea-9250-526ac8b08ff2.png">

This change also resets the icons to their default positions on large screens:

#### Before
<img width="584" alt="Screen Shot 2020-08-29 at 4 32 11 PM" src="https://user-images.githubusercontent.com/41145903/91647950-19b9ab80-ea16-11ea-8537-735883e67ed4.png">

### After
<img width="584" alt="Screen Shot 2020-08-29 at 4 33 10 PM" src="https://user-images.githubusercontent.com/41145903/91647951-1de5c900-ea16-11ea-9d60-729e208b622e.png">
