### PR TITLE
Move Map Compass from behind Search bar

### DIFF
--- a/bm-persona/Map/MapViewController.swift
+++ b/bm-persona/Map/MapViewController.swift
@@ -9,6 +9,8 @@
 import UIKit
 import MapKit
 
+fileprivate let kViewMargin: CGFloat = 16
+
 // MARK: - MapViewController
 
 class MapViewController: UIViewController, SearchDrawerViewDelegate {
@@ -84,6 +86,7 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
         super.viewDidAppear(animated)
         mapView.isZoomEnabled = true
         centerMapOnLocation(CLLocation(latitude: CLLocationDegrees(exactly: 37.871684)!, longitude: CLLocationDegrees(-122.259934)), mapView: mapView)
+        updateCompassPosition()
     }
     
     private func centerMapOnLocation(_ location: CLLocation, mapView: MKMapView) {
@@ -91,6 +94,17 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
         let coordinateRegion = MKCoordinateRegion(center: location.coordinate,
                                                   latitudinalMeters: regionRadius * 2.0, longitudinalMeters: regionRadius * 2.0)
         mapView.setRegion(coordinateRegion, animated: true)
+    }
+
+    /// Repoisitions the map's compass so that it is not obscured by the search bar.
+    private func updateCompassPosition() {
+        mapView.showsCompass = false
+        let compass = MKCompassButton(mapView: mapView)
+        view.addSubview(compass)
+        // Position the compass to bottom-right of `FilterView`
+        compass.translatesAutoresizingMaskIntoConstraints = false
+        compass.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
+        compass.topAnchor.constraint(equalTo: filterView.bottomAnchor, constant: kViewMargin).isActive = true
     }
     
     private func setupSubviews() {
@@ -112,7 +126,7 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
         
         filterView.translatesAutoresizingMaskIntoConstraints = false
         filterView.heightAnchor.constraint(equalToConstant: FilterViewCell.kCellSize.height).isActive = true
-        filterView.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: 17).isActive = true
+        filterView.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: kViewMargin).isActive = true
         filterView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
         filterView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
         filterView.contentInset = UIEdgeInsets(top: 0, left: view.layoutMargins.left,


### PR DESCRIPTION
The default map compass is obscured by the search bar. Instead, move the compass to below the map marker buttons, so that it is not obscured.

### Before
![Image from iOS](https://user-images.githubusercontent.com/41145903/91648994-825b5500-ea23-11ea-8ce5-df149dbe2373.jpg)

### After
<img width="559" alt="Screen Shot 2020-08-29 at 6 11 33 PM" src="https://user-images.githubusercontent.com/41145903/91648997-86877280-ea23-11ea-8191-625899f63cb8.png">

The compass appears when the map is rotated, so test this change by rotating the map. In the simulator, this can be done by holding down `Option` and dragging. Also verify that clicking the compass resets the map to its original orientation.