### PR TITLE
Fix searching for items that aren't Dining Hall or Library

### DIFF
--- a/bm-persona/Dining/DiningViewController.swift
+++ b/bm-persona/Dining/DiningViewController.swift
@@ -90,7 +90,7 @@ extension DiningViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        presentDetail(type: DiningLocation.self, item: self.filterTableView.filteredData[indexPath.row], containingVC: mainContainer!, position: .full)
+        presentDetail(type: DiningHall.self, item: self.filterTableView.filteredData[indexPath.row], containingVC: mainContainer!, position: .full)
         tableView.deselectRow(at: indexPath, animated: true)
     }
 }

--- a/bm-persona/Drawer/SearchDrawerViewDelegate.swift
+++ b/bm-persona/Drawer/SearchDrawerViewDelegate.swift
@@ -20,7 +20,7 @@ extension SearchDrawerViewDelegate where Self: UIViewController {
      type is set to DiningHall, Library, etc. to determine what type of detail view is needed */
     func presentDetail(type: AnyClass, item: SearchItem, containingVC: UIViewController, position: DrawerState) {
         let containingView = containingVC.view!
-        if type == DiningLocation.self {
+        if type == DiningHall.self {
             drawerViewController = DiningDetailViewController()
             (drawerViewController as! DiningDetailViewController).diningHall = (item as! DiningLocation)
         } else if type == Library.self {

--- a/bm-persona/Map/MapViewController.swift
+++ b/bm-persona/Map/MapViewController.swift
@@ -302,18 +302,17 @@ extension MapViewController: SearchResultsViewDelegate {
     
     // drop new pin and show detail view on search
     func choosePlacemark(_ placemark: MapPlacemark) {
-        let location = placemark.location
         // remove last search pin
         removeAnnotations(type: SearchAnnotation.self)
-        if location != nil && location?.coordinate.latitude != Double.nan && location?.coordinate.longitude != Double.nan {
+        if let location = placemark.location, location.coordinate.latitude != Double.nan && location.coordinate.longitude != Double.nan {
             let regionRadius: CLLocationDistance = 250
             // center map on searched location
-            let coordinateRegion = MKCoordinateRegion(center: location!.coordinate,
+            let coordinateRegion = MKCoordinateRegion(center: location.coordinate,
                                                       latitudinalMeters: regionRadius * 2.0, longitudinalMeters: regionRadius * 2.0)
             mapView.setRegion(coordinateRegion, animated: true)
             let item = placemark.item
             if item != nil {
-                let annotation = SearchAnnotation(item: item!, location: location!.coordinate)
+                let annotation = SearchAnnotation(item: item!, location: location.coordinate)
                 annotation.title = item!.searchName
                 searchAnnotation = annotation
                 // add and select marker for search item, remove resource view if any
@@ -323,11 +322,11 @@ extension MapViewController: SearchResultsViewDelegate {
                     mapView.deselectAnnotation(markerDetail.marker, animated: true)
                 }
                 // if the new search item has a detail view: remove the old detail view, show the new one
-                if let hall = item as? DiningLocation {
+                if let hall = item as? DiningHall {
                     if drawerViewController != nil {
                         mainContainer?.dismissTop(showNext: false)
                     }
-                    presentDetail(type: DiningLocation.self, item: hall, containingVC: mainContainer!, position: .middle)
+                    presentDetail(type: DiningHall.self, item: hall, containingVC: mainContainer!, position: .middle)
                 } else if let lib = item as? Library {
                     if drawerViewController != nil {
                         mainContainer?.dismissTop(showNext: false)
@@ -339,7 +338,6 @@ extension MapViewController: SearchResultsViewDelegate {
                     if drawerViewController != nil {
                         mainContainer?.dismissTop()
                     }
-                    return
                 }
             }
         }


### PR DESCRIPTION
Remove detail views for cafes - cafes now behave like any other search item (just drops pin).

All non-Dining Hall non-Library search items will drop pin, remove search results, pull up the latest drawer to its previous position before searching.

Video of behavior: https://www.notion.so/Searching-for-Campus-Resources-not-behaving-as-expected-31d2d45c664f4da29e04b6c977474cd6