### PR TITLE
Labels getting truncated - overview card

### DIFF
--- a/bm-persona/Common/DetailView/LocationDetailView.swift
+++ b/bm-persona/Common/DetailView/LocationDetailView.swift
@@ -49,7 +49,7 @@ class LocationDetailView: IconPairView, DetailView {
         label.textColor = Color.blackText
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.75
-        label.numberOfLines = 1
+        label.numberOfLines = 2
 
         super.init(icon: icon, iconHeight: 16, iconWidth: 16, attachedView: label)
 

--- a/bm-persona/Common/DetailView/OverviewCardView.swift
+++ b/bm-persona/Common/DetailView/OverviewCardView.swift
@@ -9,8 +9,8 @@
 import UIKit
 import MapKit
 
-fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-fileprivate let kViewMargin: CGFloat = 16
+fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+fileprivate let kViewMargin: CGFloat = 10
 
 // all the possible elements on the card, used to exclude certain elements even if they are available
 enum OverviewElements {
@@ -211,7 +211,7 @@ class OverviewCardView: CardView {
         stack.axis = .horizontal
         stack.alignment = .center
         stack.distribution = .equalSpacing
-        stack.spacing = kViewMargin
+        stack.spacing = 5
         return stack
     }()
     
@@ -337,7 +337,7 @@ class OverviewCardView: CardView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.75
-        label.numberOfLines = 1
+        label.numberOfLines = 2
         return label
     }()
     

--- a/bm-persona/Common/DetailView/OverviewCardView.swift
+++ b/bm-persona/Common/DetailView/OverviewCardView.swift
@@ -282,7 +282,7 @@ class OverviewCardView: CardView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.75
-        label.numberOfLines = 1
+        label.numberOfLines = 2
         return label
     }()
     

--- a/bm-persona/Common/DetailView/OverviewCardView.swift
+++ b/bm-persona/Common/DetailView/OverviewCardView.swift
@@ -262,7 +262,7 @@ class OverviewCardView: CardView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.75
-        label.numberOfLines = 2
+        label.numberOfLines = 0
         return label
     }()
     


### PR DESCRIPTION
Overview card elements were getting truncated, especially on smaller phones.
Addressed by making labels 2 lines, cutting margins from 16 to 10.

Screenshots: first 3 iPhone SE, second 3 iPhone X

![Simulator Screen Shot - iPhone SE (1st generation) - 2020-08-30 at 18 47 37](https://user-images.githubusercontent.com/20230668/91675803-8904cd80-eaf2-11ea-8666-0d3637255b3a.png)
![Simulator Screen Shot - iPhone SE (1st generation) - 2020-08-30 at 18 47 52](https://user-images.githubusercontent.com/20230668/91675805-8ace9100-eaf2-11ea-9521-804dabac06d9.png)
![Simulator Screen Shot - iPhone SE (1st generation) - 2020-08-30 at 18 51 30](https://user-images.githubusercontent.com/20230668/91675806-8bffbe00-eaf2-11ea-9c5d-db1ef6def0d2.png)
![IMG_1641](https://user-images.githubusercontent.com/20230668/91675839-a9348c80-eaf2-11ea-81d9-d8524a11a37c.PNG)
![IMG_1639](https://user-images.githubusercontent.com/20230668/91675841-aafe5000-eaf2-11ea-9f93-bf41255159f6.PNG)
![IMG_1640](https://user-images.githubusercontent.com/20230668/91675842-ac2f7d00-eaf2-11ea-82f6-04942fa8d86e.PNG)


