### PR TITLE
Map Marker Stretching Quick Fix

### DIFF
--- a/bm-persona/Map/MapMarkerDetailView.swift
+++ b/bm-persona/Map/MapMarkerDetailView.swift
@@ -138,10 +138,16 @@ class MapMarkerDetailView: UIView {
         notesLabel.text = marker.subtitle
         
         detailStack.removeAllArrangedSubviews()
+        var containsFlexibleView = false
         for property: MapMarkerDetail in [.distance, .openNow, .location] {
             if let view = property.view(marker) {
                 detailStack.addArrangedSubview(view)
+                containsFlexibleView = containsFlexibleView || !property.inflexible
             }
+        }
+        // Add empty 'padding' view to prevent stretching of 'inflexible' views.
+        if !containsFlexibleView {
+            detailStack.addArrangedSubview(UIView())
         }
         
         verticalStack.addArrangedSubview(nameLabel)
@@ -168,6 +174,11 @@ enum MapMarkerDetail {
     case location
     case openNow
     case distance
+
+    /** Boolean that is `true` if the view for this detail should not be stretched horizontally. */
+    var inflexible: Bool {
+        return self != .location
+    }
     
     /** Helper that returns a view next to an icon */
     func viewWithIcon(_ icon: UIImage?, view: UIView) -> UIView {


### PR DESCRIPTION
When there is no location data available, the clock icon for open status for Map Markers is stretched:
![filename](https://user-images.githubusercontent.com/41145903/92314116-72de8d80-ef88-11ea-909e-cb715ca84daa.jpeg)

This is because the horizontal stack view is constrained to the width of the vertical stack view, and its items are stretched to fill the width. When the location data is available, this is fine, since the label for the location will take the remaining width. A quick workaround for the case when location data is unavailable is to add an empty view at the end of the horizontal stack that is stretched instead of the detail views.

To test this PR, remove `.location` from [this line](https://github.com/asuc-octo/berkeley-mobile-ios/blob/9984bcb11bcdbe668d78cb4b9edf81019d3688d9/bm-persona/Map/MapMarkerDetailView.swift#L142) to remove it from being shown, since it looks like all Map Markers on Firebase have non null locations right now.

The icon should no longer be stretched out:
<img width="559" alt="Screen Shot 2020-09-05 at 2 57 53 PM" src="https://user-images.githubusercontent.com/41145903/92314170-44ad7d80-ef89-11ea-9a8a-4be8ecdae20f.png">
