### PR TITLE
Change "Nearby" button to sort

### DIFF
--- a/bm-persona.xcodeproj/project.pbxproj
+++ b/bm-persona.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		29061D41241C450E002BC9D9 /* HasLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29061D40241C450E002BC9D9 /* HasLocation.swift */; };
 		2913595724B136BE00DE9AD6 /* CollapsibleCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2913595624B136BE00DE9AD6 /* CollapsibleCardView.swift */; };
 		2913595924B13DF200DE9AD6 /* OpenTimesCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2913595824B13DF200DE9AD6 /* OpenTimesCardView.swift */; };
+		291B11E025043FF100F737A8 /* Sort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291B11DF25043FF100F737A8 /* Sort.swift */; };
+		291B11E225044BDB00F737A8 /* HasName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291B11E125044BDB00F737A8 /* HasName.swift */; };
 		29345E2724A7E76300859A88 /* OverviewCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29345E2624A7E76300859A88 /* OverviewCardView.swift */; };
 		29345E2924A7E7AC00859A88 /* HasPhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29345E2824A7E7AC00859A88 /* HasPhoneNumber.swift */; };
 		29345E2B24A7EC2B00859A88 /* HasImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29345E2A24A7EC2B00859A88 /* HasImage.swift */; };
@@ -175,6 +177,8 @@
 		29061D40241C450E002BC9D9 /* HasLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasLocation.swift; sourceTree = "<group>"; };
 		2913595624B136BE00DE9AD6 /* CollapsibleCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleCardView.swift; sourceTree = "<group>"; };
 		2913595824B13DF200DE9AD6 /* OpenTimesCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTimesCardView.swift; sourceTree = "<group>"; };
+		291B11DF25043FF100F737A8 /* Sort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sort.swift; sourceTree = "<group>"; };
+		291B11E125044BDB00F737A8 /* HasName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasName.swift; sourceTree = "<group>"; };
 		29345E2624A7E76300859A88 /* OverviewCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewCardView.swift; sourceTree = "<group>"; };
 		29345E2824A7E7AC00859A88 /* HasPhoneNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasPhoneNumber.swift; sourceTree = "<group>"; };
 		29345E2A24A7EC2B00859A88 /* HasImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasImage.swift; sourceTree = "<group>"; };
@@ -419,6 +423,7 @@
 			isa = PBXGroup;
 			children = (
 				132087AE23F3B05D00AE273C /* Filter.swift */,
+				291B11DF25043FF100F737A8 /* Sort.swift */,
 				13B39AB323E777AC0039FBA2 /* FilterView.swift */,
 				13B39AB223E777AC0039FBA2 /* FilterViewCell.swift */,
 			);
@@ -435,6 +440,7 @@
 				29345E2A24A7EC2B00859A88 /* HasImage.swift */,
 				29AB5BBE241D8766007C3ECA /* HasOpenTimes.swift */,
 				299ACFB3244A5F90000F3E86 /* HasOccupancy.swift */,
+				291B11E125044BDB00F737A8 /* HasName.swift */,
 			);
 			path = ItemProtocols;
 			sourceTree = "<group>";
@@ -822,6 +828,7 @@
 				306A54FE236142B800D59A7F /* DrawerViewController.swift in Sources */,
 				13B39A8B23E682850039FBA2 /* Date+Extension.swift in Sources */,
 				135D7F75243A9AB3003F8BD1 /* GymClassType.swift in Sources */,
+				291B11E025043FF100F737A8 /* Sort.swift in Sources */,
 				29345E2924A7E7AC00859A88 /* HasPhoneNumber.swift in Sources */,
 				130FA59E243B1243005DC752 /* DiningRestriction.swift in Sources */,
 				556CCD2D23E79EC100F41BF9 /* TabBarController.swift in Sources */,
@@ -864,6 +871,7 @@
 				297678892426D2C500FDD1EB /* SearchDrawerViewController.swift in Sources */,
 				29CB280A2404DD71009A2CFB /* FilterTableViewCell.swift in Sources */,
 				55DCF79623723CF2001B01B8 /* UIView+Extensions.swift in Sources */,
+				291B11E225044BDB00F737A8 /* HasName.swift in Sources */,
 				01BC8EB224E8D920005B4969 /* IconPairView.swift in Sources */,
 				306A54EA23613E3A00D59A7F /* AppDelegate.swift in Sources */,
 				1336A31C241C400800949F32 /* GymClass.swift in Sources */,

--- a/bm-persona.xcodeproj/xcshareddata/xcschemes/bm-persona.xcscheme
+++ b/bm-persona.xcodeproj/xcshareddata/xcschemes/bm-persona.xcscheme
@@ -32,8 +32,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/bm-persona.xcodeproj/xcshareddata/xcschemes/bm-persona.xcscheme
+++ b/bm-persona.xcodeproj/xcshareddata/xcschemes/bm-persona.xcscheme
@@ -32,8 +32,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/bm-persona/Common/FilterTableView/FilterTableView.swift
+++ b/bm-persona/Common/FilterTableView/FilterTableView.swift
@@ -57,6 +57,7 @@ class FilterTableView<T>: UIView {
         filter.labels = tableFunctions.map { $0.label }
         filter.filterDelegate = self
         for index in initialSelectedIndices {
+            guard index < filter.labels.count else { continue }
             filter.selectItem(index: index)
         }
         isInitialSetup = false

--- a/bm-persona/Common/FilterTableView/FilterTableView.swift
+++ b/bm-persona/Common/FilterTableView/FilterTableView.swift
@@ -18,8 +18,9 @@ class FilterTableView<T>: UIView {
     var filter: FilterView = FilterView(frame: .zero)
     var data: [T] = []
     var filteredData: [T] = []
-    var filters: [Filter<T>] = []
-    var sortFunc: ((T, T) -> Bool) = {lib1, lib2 in true}
+    var tableFunctions: [TableFunction] = []
+    var sortIndex: Int?
+    var defaultSort: ((T, T) -> Bool)
     
     override func layoutSubviews() {
         self.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
@@ -31,7 +32,7 @@ class FilterTableView<T>: UIView {
         filter.topAnchor.constraint(equalTo: self.layoutMarginsGuide.topAnchor).isActive = true
         filter.heightAnchor.constraint(equalToConstant: FilterViewCell.kCellSize.height).isActive = true
 
-        filter.labels = filters.map { $0.label }
+        filter.labels = tableFunctions.map { $0.label }
         filter.filterDelegate = self
         
         self.addSubview(tableView)
@@ -49,28 +50,36 @@ class FilterTableView<T>: UIView {
         tableView.showsVerticalScrollIndicator = false
     }
     
-    init(frame: CGRect, filters: [Filter<T>]) {
+    init(frame: CGRect, tableFunctions: [TableFunction], defaultSort: @escaping ((T, T) -> Bool)) {
+        self.defaultSort = defaultSort
         super.init(frame: frame)
-        
         missingView = MissingDataView(parentView: tableView)
-        
-        self.filters = filters
+        self.tableFunctions = tableFunctions
         self.update()
     }
     
     func setData(data: [T]) {
         self.data = data
         self.filteredData = data
-        self.filteredData.sort(by: sortFunc)
+        sort()
     }
     
     func sort() {
-        self.filteredData.sort(by: sortFunc)
+        if let sortIndex = self.sortIndex,
+           sortIndex < tableFunctions.count,
+           let sort = tableFunctions[sortIndex] as? Sort<T> {
+            self.filteredData.sort(by: sort.sort)
+        } else {
+            self.filteredData.sort(by: defaultSort)
+        }
     }
     
-    func setSortFunc(newSortFunc: @escaping ((T, T) -> Bool)) {
-        sortFunc = newSortFunc
-        sort()
+    func setSortFunc(index: Int) {
+        if index < tableFunctions.count,
+           tableFunctions[index] as? Sort<T> != nil {
+            sortIndex = index
+            sort()
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -81,7 +90,19 @@ class FilterTableView<T>: UIView {
     @objc func update() {
         workItem?.cancel()
         let data = self.data
-        workItem = Filter.apply(filters: filters, on: data, indices: filter.indexPathsForSelectedItems?.map { $0.row }, completion: {
+        guard let paths = filter.indexPathsForSelectedItems else { return }
+        let rows = paths.map { $0.row }
+        var filters: [Filter<T>] = []
+        sortIndex = nil
+        for row in rows {
+            guard row < tableFunctions.count else { continue }
+            if let filter = tableFunctions[row] as? Filter<T> {
+                filters.append(filter)
+            } else if tableFunctions[row] as? Sort<T> != nil {
+                setSortFunc(index: row)
+            }
+        }
+        workItem = Filter.apply(filters: filters, on: data, completion: {
           filtered in
             self.filteredData = filtered
             self.sort()

--- a/bm-persona/Common/FilterView/Filter.swift
+++ b/bm-persona/Common/FilterView/Filter.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Filter<T> {
+struct Filter<T>: TableFunction {
   
     var label: String
     var filter: ((T) -> Bool)?

--- a/bm-persona/Common/FilterView/FilterView.swift
+++ b/bm-persona/Common/FilterView/FilterView.swift
@@ -100,4 +100,9 @@ extension FilterView: UICollectionViewDataSource, UICollectionViewDelegate, UICo
             deselectItem(at: indexPath, animated: false)
         }
     }
+    
+    func selectItem(index: Int) {
+        guard index < labels.count else { return }
+        self.selectItem(at: IndexPath(row: index, section: 0), animated: false, scrollPosition: .left)
+    }
 }

--- a/bm-persona/Common/FilterView/Sort.swift
+++ b/bm-persona/Common/FilterView/Sort.swift
@@ -1,0 +1,20 @@
+//
+//  Sort.swift
+//  bm-persona
+//
+//  Created by Shawn Huang on 9/5/20.
+//  Copyright © 2020 RJ Pimentel. All rights reserved.
+//
+
+import Foundation
+
+protocol TableFunction {
+    var label: String { get set }
+}
+
+struct Sort<T>: TableFunction {
+    
+    var label: String
+    var sort: ((T, T) -> Bool)
+  
+}

--- a/bm-persona/Data/ItemProtocols/HasLocation.swift
+++ b/bm-persona/Data/ItemProtocols/HasLocation.swift
@@ -26,10 +26,6 @@ protocol HasLocation {
 
     /// Returns a comparator used to compare two items by their distance to the user.
     static func locationComparator() -> ((HasLocation, HasLocation) -> Bool)
-
-    /// Returns a closure that filters items by their distance to the user.
-    static func locationFilter(by maxDistance: Double) -> ((HasLocation) -> Bool)
-    
 }
 
 extension HasLocation {
@@ -49,14 +45,5 @@ extension HasLocation {
 
     static func locationComparator() -> ((HasLocation, HasLocation) -> Bool) {
         return SortingFunctions.sortClose(loc1:loc2:)
-    }
-
-    static func locationFilter(by maxDistance: Double) -> ((HasLocation) -> Bool) {
-        return { item in
-            if let distance = item.distanceToUser, distance <= maxDistance {
-                return true
-            }
-            return false
-        }
     }
 }

--- a/bm-persona/Data/ItemProtocols/HasName.swift
+++ b/bm-persona/Data/ItemProtocols/HasName.swift
@@ -1,0 +1,13 @@
+//
+//  HasName.swift
+//  bm-persona
+//
+//  Created by Shawn Huang on 9/5/20.
+//  Copyright © 2020 RJ Pimentel. All rights reserved.
+//
+
+import Foundation
+
+protocol HasName {
+    var name: String { get }
+}

--- a/bm-persona/Data/ItemProtocols/SearchItem.swift
+++ b/bm-persona/Data/ItemProtocols/SearchItem.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol SearchItem {
+protocol SearchItem: HasName {
 
     var searchName: String { get }
     var location: (Double, Double) { get }

--- a/bm-persona/Data/SortingFunctions.swift
+++ b/bm-persona/Data/SortingFunctions.swift
@@ -16,7 +16,7 @@ class SortingFunctions {
         if d1 == d2,
             let loc1 = loc1 as? SearchItem,
             let loc2 = loc2 as? SearchItem {
-            return sortAlph(loc1: loc1, loc2: loc2)
+            return sortAlph(item1: loc1, item2: loc2)
         } else if d2 == nil {
             return true
         } else if d1 == nil {
@@ -26,7 +26,7 @@ class SortingFunctions {
         }
     }
     
-    static func sortAlph(loc1: SearchItem, loc2: SearchItem) -> Bool {
-        return loc1.searchName < loc2.searchName
+    static func sortAlph(item1: HasName, item2: HasName) -> Bool {
+        return item1.name < item2.name
     }
 }

--- a/bm-persona/Dining/DiningDataSource/DiningItem.swift
+++ b/bm-persona/Dining/DiningDataSource/DiningItem.swift
@@ -12,7 +12,7 @@ import Foundation
 typealias DiningMenu = Array<DiningItem>
 
 /** Object representing a single dish/item. */
-class DiningItem {
+class DiningItem: HasName {
     
     let name: String
     var isFavorited: Bool = false

--- a/bm-persona/Dining/DiningDataSource/DiningLocation.swift
+++ b/bm-persona/Dining/DiningDataSource/DiningLocation.swift
@@ -12,8 +12,6 @@ import UIKit
 class DiningLocation: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOpenTimes, HasOccupancy {
     var icon: UIImage?
     
-    static var nearbyDistance: Double = 10
-    
     var isFavorited: Bool = false
     var searchName: String {
         return name

--- a/bm-persona/Dining/DiningDetailViewController.swift
+++ b/bm-persona/Dining/DiningDetailViewController.swift
@@ -19,7 +19,7 @@ class DiningDetailViewController: SearchDrawerViewController {
     var control: TabBarControl?
     var meals: MealMap = [:]
     var mealNames: [MealType] = []
-    var menuView: FilterTableView = FilterTableView<DiningItem>(frame: .zero, filters: [])
+    var menuView: FilterTableView = FilterTableView<DiningItem>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
     override var upperLimitState: DrawerState? {
         get {
             return control == nil ? .middle : nil
@@ -102,7 +102,7 @@ extension DiningDetailViewController {
         //        filters.append(filterForRestriction(name: "Soybeans", restriction: KnownRestriction.soybean, matches: true))
         //        filters.append(filterForRestriction(name: "Wheat", restriction: KnownRestriction.wheat, matches: true))
         //        filters.append(filterForRestriction(name: "No Sesame", restriction: KnownRestriction.sesame, matches: false))
-        menuView = FilterTableView(frame: .zero, filters: filters)
+        menuView = FilterTableView(frame: .zero, tableFunctions: filters, defaultSort: SortingFunctions.sortAlph(item1:item2:))
         self.menuView.tableView.register(DiningMenuCell.self, forCellReuseIdentifier: DiningMenuCell.kCellIdentifier)
         self.menuView.tableView.dataSource = self
         self.menuView.tableView.delegate = self

--- a/bm-persona/Dining/DiningViewController.swift
+++ b/bm-persona/Dining/DiningViewController.swift
@@ -140,8 +140,8 @@ extension DiningViewController {
     // Table of dining locations
     func setupTableView() {
         let functions: [TableFunction] = [
-            Sort<DiningLocation>(label: "Nearby", sort: Library.locationComparator()),
-            Filter<DiningLocation>(label: "Open", filter: {lib in lib.isOpen ?? false}),
+            Sort<DiningLocation>(label: "Nearby", sort: DiningHall.locationComparator()),
+            Filter<DiningLocation>(label: "Open", filter: {diningHall in diningHall.isOpen ?? false}),
         ]
         filterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:), initialSelectedIndices: [0, 1])
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)

--- a/bm-persona/Dining/DiningViewController.swift
+++ b/bm-persona/Dining/DiningViewController.swift
@@ -143,7 +143,7 @@ extension DiningViewController {
             Sort<DiningLocation>(label: "Nearby", sort: Library.locationComparator()),
             Filter<DiningLocation>(label: "Open", filter: {lib in lib.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:))
+        filterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:), initialSelectedIndices: [0, 1])
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = self
         self.filterTableView.tableView.delegate = self

--- a/bm-persona/Dining/DiningViewController.swift
+++ b/bm-persona/Dining/DiningViewController.swift
@@ -11,7 +11,7 @@ import MapKit
 
 class DiningViewController: UIViewController, SearchDrawerViewDelegate {
     
-    private var filterTableView: FilterTableView = FilterTableView<DiningLocation>(frame: .zero, filters: [])
+    private var filterTableView: FilterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
     private var diningLocations: [DiningLocation] = []
     
     private var headerLabel: UILabel!
@@ -41,7 +41,6 @@ class DiningViewController: UIViewController, SearchDrawerViewDelegate {
         
         setupCardView()
         
-        filterTableView.setSortFunc(newSortFunc: DiningLocation.locationComparator())
         // Update `filterTableView` when user location is updated.
         LocationManager.notificationCenter.addObserver(
             filterTableView,
@@ -140,9 +139,11 @@ extension DiningViewController {
     
     // Table of dining locations
     func setupTableView() {
-        let filters = [Filter<DiningLocation>(label: "Nearby", filter: DiningLocation.locationFilter(by: DiningLocation.nearbyDistance)),
-            Filter<DiningLocation>(label: "Open", filter: {dh in dh.isOpen ?? false})]
-        self.filterTableView = FilterTableView(frame: .zero, filters: filters)
+        let functions: [TableFunction] = [
+            Sort<DiningLocation>(label: "Nearby", sort: Library.locationComparator()),
+            Filter<DiningLocation>(label: "Open", filter: {lib in lib.isOpen ?? false}),
+        ]
+        filterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:))
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = self
         self.filterTableView.tableView.delegate = self

--- a/bm-persona/Fitness/FitnessViewController.swift
+++ b/bm-persona/Fitness/FitnessViewController.swift
@@ -257,8 +257,8 @@ extension FitnessViewController {
     
     func setupFilterTableView() {
         let functions: [TableFunction] = [
-            Sort<Gym>(label: "Nearby", sort: Library.locationComparator()),
-            Filter<Gym>(label: "Open", filter: {lib in lib.isOpen ?? false}),
+            Sort<Gym>(label: "Nearby", sort: Gym.locationComparator()),
+            Filter<Gym>(label: "Open", filter: {gym in gym.isOpen ?? false}),
         ]
         filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:), initialSelectedIndices: [0, 1])
         self.filterTableView.tableView.allowsSelection = false

--- a/bm-persona/Fitness/FitnessViewController.swift
+++ b/bm-persona/Fitness/FitnessViewController.swift
@@ -260,7 +260,7 @@ extension FitnessViewController {
             Sort<Gym>(label: "Nearby", sort: Library.locationComparator()),
             Filter<Gym>(label: "Open", filter: {lib in lib.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:))
+        filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:), initialSelectedIndices: [0, 1])
         self.filterTableView.tableView.allowsSelection = false
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = gymsController

--- a/bm-persona/Fitness/FitnessViewController.swift
+++ b/bm-persona/Fitness/FitnessViewController.swift
@@ -30,7 +30,7 @@ class FitnessViewController: UIViewController {
     // For use in the "Upcoming" card
     private var classesCollection: CardCollectionView!
     // To display a list of gyms in the "Fitness Centers" card
-    var filterTableView = FilterTableView<Gym>(frame: .zero, filters: [])
+    var filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
     
     var gyms: [Gym] = []
     var upcomingClasses: [GymClass] = []
@@ -49,8 +49,7 @@ class FitnessViewController: UIViewController {
         setupUpcomingClasses()
         setupTodayClasses()
         setupGyms()
-
-        filterTableView.setSortFunc(newSortFunc: Gym.locationComparator())
+        
         // Update `filterTableView` when user location is updated.
         LocationManager.notificationCenter.addObserver(
             filterTableView,
@@ -257,11 +256,11 @@ extension FitnessViewController {
     }
     
     func setupFilterTableView() {
-        let filters = [
-            Filter<Gym>(label: "Nearby", filter: Gym.locationFilter(by: Gym.nearbyDistance)),
-            Filter<Gym>(label: "Open", filter: {gym in gym.isOpen ?? false}),
+        let functions: [TableFunction] = [
+            Sort<Gym>(label: "Nearby", sort: Library.locationComparator()),
+            Filter<Gym>(label: "Open", filter: {lib in lib.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView(frame: .zero, filters: filters)
+        filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:))
         self.filterTableView.tableView.allowsSelection = false
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = gymsController

--- a/bm-persona/Fitness/GymDataSource/Gym.swift
+++ b/bm-persona/Fitness/GymDataSource/Gym.swift
@@ -10,8 +10,6 @@ import Foundation
 import UIKit
 
 class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOpenTimes, HasOccupancy {
-    
-    static var nearbyDistance: Double = 10
     var icon: UIImage?
     
     var searchName: String {

--- a/bm-persona/Libraries/LibraryDataSource/Library.swift
+++ b/bm-persona/Libraries/LibraryDataSource/Library.swift
@@ -10,9 +10,6 @@ import UIKit
 import MapKit
 
 class Library: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOpenTimes, HasOccupancy {
-    
-    static var nearbyDistance: Double = 10
-    
     var searchName: String {
         return name
     }

--- a/bm-persona/Libraries/LibraryViewController.swift
+++ b/bm-persona/Libraries/LibraryViewController.swift
@@ -20,7 +20,7 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
     // SearchDrawerViewDelegate property
     var mainContainer: MainContainerViewController?
     
-    var filterTableView: FilterTableView = FilterTableView<Library>(frame: .zero, filters: [])
+    var filterTableView: FilterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
     var safeArea: UILayoutGuide!
     var libraries: [Library] = []
     
@@ -40,8 +40,7 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        filterTableView.setSortFunc(newSortFunc: Library.locationComparator())
+        
         // Update `filterTableView` when user location is updated.
         LocationManager.notificationCenter.addObserver(
             filterTableView,
@@ -111,11 +110,11 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
     }
     
     func setupFilterTableView() {
-        let filters = [
-            Filter<Library>(label: "Nearby", filter: Library.locationFilter(by: Library.nearbyDistance)),
+        let functions: [TableFunction] = [
+            Sort<Library>(label: "Nearby", sort: Library.locationComparator()),
             Filter<Library>(label: "Open", filter: {lib in lib.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView(frame: .zero, filters: filters)
+        filterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:))
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = self
         self.filterTableView.tableView.delegate = self

--- a/bm-persona/Libraries/LibraryViewController.swift
+++ b/bm-persona/Libraries/LibraryViewController.swift
@@ -114,7 +114,7 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
             Sort<Library>(label: "Nearby", sort: Library.locationComparator()),
             Filter<Library>(label: "Open", filter: {lib in lib.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:))
+        filterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:), initialSelectedIndices: [0, 1])
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = self
         self.filterTableView.tableView.delegate = self

--- a/bm-persona/Resources/ResourcesDataSource/Resource.swift
+++ b/bm-persona/Resources/ResourcesDataSource/Resource.swift
@@ -12,8 +12,6 @@ import UIKit
 class Resource: SearchItem, HasLocation, HasOpenTimes {
     var icon: UIImage?
     
-    static var nearbyDistance: Double = 10
-    
     var searchName: String {
         return name
     }

--- a/bm-persona/Resources/ResourcesViewController.swift
+++ b/bm-persona/Resources/ResourcesViewController.swift
@@ -15,7 +15,7 @@ class ResourcesViewController: UIViewController {
     private var resourcesLabel: UILabel!
 
     private var resourcesCard: CardView!
-    private var resourcesTable: FilterTableView = FilterTableView<Resource>(frame: .zero, filters: [])
+    private var resourcesTable: FilterTableView = FilterTableView<Resource>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
     
     private var resourceEntries: [Resource] = []
 
@@ -81,7 +81,7 @@ extension ResourcesViewController {
         card.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
         
         let filters = [Filter<Resource>(label: "Open", filter: {resource in resource.isOpen ?? false})]
-        resourcesTable = FilterTableView(frame: .zero, filters: filters)
+        resourcesTable = FilterTableView(frame: .zero, tableFunctions: filters, defaultSort: SortingFunctions.sortAlph(item1:item2:))
         resourcesTable.tableView.allowsSelection = false
         
         resourcesTable.tableView.delegate = self

--- a/bm-persona/Resources/ResourcesViewController.swift
+++ b/bm-persona/Resources/ResourcesViewController.swift
@@ -39,12 +39,12 @@ class ResourcesViewController: UIViewController {
 
 extension ResourcesViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return resourceEntries.count
+        return self.resourcesTable.filteredData.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = ResourceTableViewCell()
-        cell.cellConfigure(entry: resourceEntries[indexPath.row])
+        cell.cellConfigure(entry: self.resourcesTable.filteredData[indexPath.row])
         return cell
     }
     
@@ -81,7 +81,7 @@ extension ResourcesViewController {
         card.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
         
         let filters = [Filter<Resource>(label: "Open", filter: {resource in resource.isOpen ?? false})]
-        resourcesTable = FilterTableView(frame: .zero, tableFunctions: filters, defaultSort: SortingFunctions.sortAlph(item1:item2:))
+        resourcesTable = FilterTableView(frame: .zero, tableFunctions: filters, defaultSort: SortingFunctions.sortAlph(item1:item2:), initialSelectedIndices: [0])
         resourcesTable.tableView.allowsSelection = false
         
         resourcesTable.tableView.delegate = self


### PR DESCRIPTION
"Nearby" now sorts by distance instead of filtering by < 10 mi.
FilterTableView can now handle sorts as well as filters.
Default select both "nearby" and "open".
Fixed bug with Resources page (didn't use filtered data so filter didn't work).

Added:
- TableFunction protocol - includes sorts and filters
- Sort struct
- HasName protocol so that alphabetical sort works on anything with a name (previously operated on SearchItems but that didn't work with menu items)
