### PR TITLE
Gym and Resource Detail Views

### DIFF
--- a/bm-persona.xcodeproj/project.pbxproj
+++ b/bm-persona.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		01BC8EB024E8C3E3005B4969 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BC8EAF24E8C3E3005B4969 /* DetailView.swift */; };
 		01BC8EB224E8D920005B4969 /* IconPairView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BC8EB124E8D920005B4969 /* IconPairView.swift */; };
+		01D11B8E2504453B00BDF660 /* ScrollingStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B8D2504453B00BDF660 /* ScrollingStackView.swift */; };
+		01D11B902504560700BDF660 /* GymDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B8F2504560700BDF660 /* GymDetailViewController.swift */; };
+		01D11B9225045FC900BDF660 /* ResourceDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B9125045FC900BDF660 /* ResourceDetailViewController.swift */; };
 		01FA50F124E8B33100DCC490 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA50F024E8B33100DCC490 /* LocationManager.swift */; };
 		01FA50F324E8BA5400DCC490 /* LocationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA50F224E8BA5400DCC490 /* LocationDetailView.swift */; };
 		130FA59E243B1243005DC752 /* DiningRestriction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130FA59D243B1243005DC752 /* DiningRestriction.swift */; };
@@ -128,6 +131,9 @@
 /* Begin PBXFileReference section */
 		01BC8EAF24E8C3E3005B4969 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		01BC8EB124E8D920005B4969 /* IconPairView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconPairView.swift; path = "bm-persona/Common/IconPairView.swift"; sourceTree = SOURCE_ROOT; };
+		01D11B8D2504453B00BDF660 /* ScrollingStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingStackView.swift; sourceTree = "<group>"; };
+		01D11B8F2504560700BDF660 /* GymDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymDetailViewController.swift; sourceTree = "<group>"; };
+		01D11B9125045FC900BDF660 /* ResourceDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDetailViewController.swift; sourceTree = "<group>"; };
 		01FA50F024E8B33100DCC490 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		01FA50F224E8BA5400DCC490 /* LocationDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDetailView.swift; sourceTree = "<group>"; };
 		130FA59D243B1243005DC752 /* DiningRestriction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiningRestriction.swift; sourceTree = "<group>"; };
@@ -362,6 +368,7 @@
 			children = (
 				13EA64C62399CDF900FD8E13 /* GymDataSource */,
 				1336A31D241C400F00949F32 /* GymClassDataSource */,
+				01D11B8F2504560700BDF660 /* GymDetailViewController.swift */,
 				13E25DFC238C949E00B670B5 /* FitnessViewController.swift */,
 				135D7F78243AA6B1003F8BD1 /* Fitness+Controllers */,
 			);
@@ -392,6 +399,7 @@
 				55C6936A240E143500400B60 /* ResourceTableViewCell.swift */,
 				5516088724393F3F00B1E55B /* MissingDataView.swift */,
 				2913595624B136BE00DE9AD6 /* CollapsibleCardView.swift */,
+				01D11B8D2504453B00BDF660 /* ScrollingStackView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -630,6 +638,7 @@
 			isa = PBXGroup;
 			children = (
 				553EF6AA2404E29800D2955E /* ResourcesDataSource */,
+				01D11B9125045FC900BDF660 /* ResourceDetailViewController.swift */,
 				556DB0DE23E7F60900F12721 /* ResourcesViewController.swift */,
 			);
 			path = Resources;
@@ -878,6 +887,7 @@
 				29345E2B24A7EC2B00859A88 /* HasImage.swift in Sources */,
 				2913595924B13DF200DE9AD6 /* OpenTimesCardView.swift in Sources */,
 				13135BB3241244370056B169 /* FilterViewCell.swift in Sources */,
+				01D11B9225045FC900BDF660 /* ResourceDetailViewController.swift in Sources */,
 				13580AF62437D7E700D309AA /* LibraryDetailViewController.swift in Sources */,
 				135D7F77243A9BD1003F8BD1 /* Colors+GymClass.swift in Sources */,
 				55DCF7A123724835001B01B8 /* MaterialButton.swift in Sources */,
@@ -904,10 +914,12 @@
 				29387E9B24BBBD9D00070BCE /* CALayerExtension.swift in Sources */,
 				1396013323865E2E005E4788 /* CardCollectionView.swift in Sources */,
 				13B39A9A23E6A33C0039FBA2 /* LibraryDataSource.swift in Sources */,
+				01D11B8E2504453B00BDF660 /* ScrollingStackView.swift in Sources */,
 				29387E9924BBBC9300070BCE /* BarEntry+DataEntry.swift in Sources */,
 				306A54EC23613E3A00D59A7F /* SceneDelegate.swift in Sources */,
 				01FA50F124E8B33100DCC490 /* LocationManager.swift in Sources */,
 				29345E2724A7E76300859A88 /* OverviewCardView.swift in Sources */,
+				01D11B902504560700BDF660 /* GymDetailViewController.swift in Sources */,
 				55AF442D2453ACE600F13232 /* DiningLocation.swift in Sources */,
 				1336A329241DA56100949F32 /* DiningHallDataSource.swift in Sources */,
 				136DC97B2398B4D1009B1810 /* UIViewController+Extensions.swift in Sources */,

--- a/bm-persona/Common/DetailView/OpenTimesCardView.swift
+++ b/bm-persona/Common/DetailView/OpenTimesCardView.swift
@@ -112,7 +112,10 @@ class OpenTimesCardView: CollapsibleCardView {
         formatter.timeStyle = .short
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = formatter.string(from: interval.start, to: interval.end)
+        // Set to the same day (today) so formatter will not display dates for intervals spanning multiple days
+        let start = interval.start.sameTimeToday() ?? interval.start
+        let end = interval.end.sameTimeToday() ?? interval.end
+        label.text = formatter.string(from: start, to: end)
         // bold label if the current time is in the interval and it's in the openedView
         if shouldBoldIfCurrent, interval.contains(Date()) {
             label.font = Font.bold(10)

--- a/bm-persona/Common/DetailView/OpenTimesCardView.swift
+++ b/bm-persona/Common/DetailView/OpenTimesCardView.swift
@@ -112,10 +112,12 @@ class OpenTimesCardView: CollapsibleCardView {
         formatter.timeStyle = .short
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        // Set to the same day (today) so formatter will not display dates for intervals spanning multiple days
-        let start = interval.start.sameTimeToday() ?? interval.start
-        let end = interval.end.sameTimeToday() ?? interval.end
-        label.text = formatter.string(from: start, to: end)
+        /* Remove the date, and only include hour and minute in string display.
+        Otherwise, string is too long when interval spans two days (e.g. 9pm-12:30am) */
+        if let start = interval.start.timeOnly(),
+            let end = interval.end.timeOnly() {
+            label.text = formatter.string(from: start, to: end)
+        }
         // bold label if the current time is in the interval and it's in the openedView
         if shouldBoldIfCurrent, interval.contains(Date()) {
             label.font = Font.bold(10)

--- a/bm-persona/Common/DetailView/OverviewCardView.swift
+++ b/bm-persona/Common/DetailView/OverviewCardView.swift
@@ -123,9 +123,9 @@ class OverviewCardView: CardView {
             let nextOpenInterval = itemWithOpenTimes.nextOpenInterval()
             /* Remove the date, and only include hour and minute in string display.
              Otherwise, string is too long when interval spans two days (e.g. 9pm-12:30am) */
-            if nextOpenInterval != nil,
-                let start = Calendar.current.date(from: Calendar.current.dateComponents([.hour, .minute], from: nextOpenInterval!.start)),
-                let end = Calendar.current.date(from: Calendar.current.dateComponents([.hour, .minute], from: nextOpenInterval!.end)) {
+            if let interval = nextOpenInterval,
+                let start = interval.start.timeOnly(),
+                let end = interval.end.timeOnly() {
                 openTimeLabel.text = formatter.string(from: start, to: end)
             }
 

--- a/bm-persona/Common/FilterTableView/FilterTableView.swift
+++ b/bm-persona/Common/FilterTableView/FilterTableView.swift
@@ -20,8 +20,13 @@ class FilterTableView<T>: UIView {
     var filteredData: [T] = []
     var filters: [Filter<T>] = []
     var sortFunc: ((T, T) -> Bool) = {lib1, lib2 in true}
-    
+
     override func layoutSubviews() {
+        super.layoutSubviews()
+        filter.labels = filters.map { $0.label }
+    }
+
+    private func setupSubviews() {
         self.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         self.addSubview(filter)
         
@@ -53,6 +58,7 @@ class FilterTableView<T>: UIView {
         super.init(frame: frame)
         
         missingView = MissingDataView(parentView: tableView)
+        setupSubviews()
         
         self.filters = filters
         self.update()

--- a/bm-persona/Common/ResourceTableViewCell.swift
+++ b/bm-persona/Common/ResourceTableViewCell.swift
@@ -10,6 +10,8 @@ import UIKit
 
 class ResourceTableViewCell: UITableViewCell {
 
+    static let kCellIdentifier = "resourceCell"
+
     private var resourceName: UILabel!
     private var resourceCategory: TagView!
     private var resourceImage: UIImageView!

--- a/bm-persona/Common/ScrollingStackView.swift
+++ b/bm-persona/Common/ScrollingStackView.swift
@@ -65,7 +65,6 @@ class ScrollingStackView: UIView {
         stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor).isActive = true
         stackView.leftAnchor.constraint(equalTo: scrollView.layoutMarginsGuide.leftAnchor).isActive = true
         stackView.rightAnchor.constraint(equalTo: scrollView.layoutMarginsGuide.rightAnchor).isActive = true
-        stackView.widthAnchor.constraint(equalTo: scrollView.layoutMarginsGuide.widthAnchor).isActive = true
     }
 
 }

--- a/bm-persona/Common/ScrollingStackView.swift
+++ b/bm-persona/Common/ScrollingStackView.swift
@@ -1,0 +1,71 @@
+//
+//  ScrollingStackView.swift
+//  bm-persona
+//
+//  Created by Kevin Hu on 9/5/20.
+//  Copyright © 2020 RJ Pimentel. All rights reserved.
+//
+
+import UIKit
+
+/// A view containing a vertical `UIStackView` in a `UIScrollView` with a dynamic content height to match the contents of the stack.
+class ScrollingStackView: UIView {
+
+    /// The `UIScrollView` containing `stackView.
+    open var scrollView: UIScrollView!
+
+    /// The `UIStackView` containing the contents of this view.
+    open var stackView: UIStackView!
+
+    /// The vertical offset applied to the contents of `scrollView` relative to this view's parent.
+    open var yOffset: CGFloat {
+        return frame.minY + scrollView.contentInset.top
+    }
+
+    // MARK: Initializers
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        setupScrollView()
+        setupStackView()
+    }
+
+    convenience init() {
+        self.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Views
+
+    func setupScrollView() {
+        scrollView = UIScrollView()
+        scrollView.contentInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+        scrollView.layoutMargins = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        addSubview(scrollView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        scrollView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
+        scrollView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
+        scrollView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+    }
+
+    func setupStackView() {
+        stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        scrollView.addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.topAnchor.constraint(equalTo: scrollView.topAnchor).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor).isActive = true
+        stackView.leftAnchor.constraint(equalTo: scrollView.layoutMarginsGuide.leftAnchor).isActive = true
+        stackView.rightAnchor.constraint(equalTo: scrollView.layoutMarginsGuide.rightAnchor).isActive = true
+        stackView.widthAnchor.constraint(equalTo: scrollView.layoutMarginsGuide.widthAnchor).isActive = true
+    }
+
+}

--- a/bm-persona/Data/ItemProtocols/HasOpenTimes.swift
+++ b/bm-persona/Data/ItemProtocols/HasOpenTimes.swift
@@ -35,7 +35,7 @@ extension HasOpenTimes {
                 }
             }
         }
-        return weeklyHours
+        return weeklyHours.isEmpty ? nil : weeklyHours
     }
     
     // TODO: Fixme, Dining halls may have open/close times that overlap multiple days.

--- a/bm-persona/Dining/DiningViewController.swift
+++ b/bm-persona/Dining/DiningViewController.swift
@@ -149,13 +149,3 @@ extension DiningViewController {
     }
     
 }
-
-extension DiningViewController {
-    func handlePanGesture(gesture: UIPanGestureRecognizer) {
-        let state = handlePan(gesture: gesture)
-        // get rid of the top detail drawer if user sends it to bottom of screen
-        if state == .hidden {
-            mainContainer?.dismissTop()
-        }
-    }
-}

--- a/bm-persona/Drawer/MainDrawerViewController.swift
+++ b/bm-persona/Drawer/MainDrawerViewController.swift
@@ -51,6 +51,8 @@ class MainDrawerViewController: DrawerViewController {
                 dining.mainContainer = container
             } else if let library = page.viewController as? LibraryViewController {
                 library.mainContainer = container
+            } else if let gym = page.viewController as? FitnessViewController {
+                gym.mainContainer = container
             }
         }
     }

--- a/bm-persona/Drawer/SearchDrawerViewDelegate.swift
+++ b/bm-persona/Drawer/SearchDrawerViewDelegate.swift
@@ -26,6 +26,12 @@ extension SearchDrawerViewDelegate where Self: UIViewController {
         } else if type == Library.self {
             drawerViewController = LibraryDetailViewController()
             (drawerViewController as! LibraryDetailViewController).library = (item as! Library)
+        } else if type == Gym.self {
+            drawerViewController = GymDetailViewController()
+            (drawerViewController as! GymDetailViewController).gym = (item as! Gym)
+        } else if type == Resource.self {
+            drawerViewController = ResourceDetailViewController()
+            (drawerViewController as! ResourceDetailViewController).resource = (item as! Resource)
         } else {
             return
         }

--- a/bm-persona/Drawer/SearchDrawerViewDelegate.swift
+++ b/bm-persona/Drawer/SearchDrawerViewDelegate.swift
@@ -65,5 +65,15 @@ extension SearchDrawerViewDelegate where Self: UIViewController {
     func computeDrawerPosition(from yPosition: CGFloat, with yVelocity: CGFloat) -> DrawerState {
         computePosition(from: yPosition, with: yVelocity, bottom: .hidden, middle: .middle, top: .full)
     }
+
+    // A default implentation of the `DrawerViewDelegate` method that removes the drawer when swiped down completely.
+    // This implementation can be overridden if needed.
+    func handlePanGesture(gesture: UIPanGestureRecognizer) {
+        let state = handlePan(gesture: gesture)
+        if state == .hidden {
+            // get rid of the top detail drawer if user sends it to bottom of screen
+            mainContainer?.dismissTop()
+        }
+    }
     
 }

--- a/bm-persona/Fitness/Fitness+Controllers/GymClassesController.swift
+++ b/bm-persona/Fitness/Fitness+Controllers/GymClassesController.swift
@@ -15,7 +15,7 @@ import UIKit
  */
 class GymClassesController: NSObject {
     
-    var vc: FitnessViewController!
+    weak var vc: FitnessViewController!
 }
 
 // MARK: - "Upcoming" UICollectionView

--- a/bm-persona/Fitness/Fitness+Controllers/GymsController.swift
+++ b/bm-persona/Fitness/Fitness+Controllers/GymsController.swift
@@ -15,13 +15,18 @@ import UIKit
  */
 class GymsController: NSObject {
     
-    var vc: FitnessViewController!
+    weak var vc: FitnessViewController!
 }
 
 // MARK: - "Fitness Centers" UITableView
 
-extension GymsController: UITableViewDataSource {
-    
+extension GymsController: UITableViewDataSource, UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        vc.presentDetail(type: Gym.self, item: vc.filterTableView.filteredData[indexPath.row], containingVC: vc.mainContainer!, position: .full)
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return vc.filterTableView.filteredData.count
     }

--- a/bm-persona/Fitness/FitnessViewController.swift
+++ b/bm-persona/Fitness/FitnessViewController.swift
@@ -14,8 +14,27 @@ fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bot
 fileprivate let kViewMargin: CGFloat = 16
 fileprivate let kTodayClassesHeight: CGFloat = 300
 
-class FitnessViewController: UIViewController {
-    
+class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
+
+    // MARK: SearchDrawerViewDelegate
+
+    // DrawerViewDelegate properties
+    var drawerViewController: DrawerViewController?
+    var initialDrawerCenter = CGPoint()
+    var drawerStatePositions: [DrawerState : CGFloat] = [:]
+    // SearchDrawerViewDelegate property
+    var mainContainer: MainContainerViewController?
+
+    func handlePanGesture(gesture: UIPanGestureRecognizer) {
+        let state = handlePan(gesture: gesture)
+        if state == .hidden {
+            // get rid of the top detail drawer if user sends it to bottom of screen
+            mainContainer?.dismissTop()
+        }
+    }
+
+    // MARK: FitnessViewController
+
     private var scrollView: UIScrollView!
     private var content: UIView!
     
@@ -262,9 +281,9 @@ extension FitnessViewController {
             Filter<Gym>(label: "Open", filter: {gym in gym.isOpen ?? false}),
         ]
         filterTableView = FilterTableView(frame: .zero, filters: filters)
-        self.filterTableView.tableView.allowsSelection = false
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = gymsController
+        self.filterTableView.tableView.delegate = gymsController
     }
     
 }

--- a/bm-persona/Fitness/FitnessViewController.swift
+++ b/bm-persona/Fitness/FitnessViewController.swift
@@ -25,14 +25,6 @@ class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
     // SearchDrawerViewDelegate property
     var mainContainer: MainContainerViewController?
 
-    func handlePanGesture(gesture: UIPanGestureRecognizer) {
-        let state = handlePan(gesture: gesture)
-        if state == .hidden {
-            // get rid of the top detail drawer if user sends it to bottom of screen
-            mainContainer?.dismissTop()
-        }
-    }
-
     // MARK: FitnessViewController
 
     private var scrollView: UIScrollView!

--- a/bm-persona/Libraries/LibraryViewController.swift
+++ b/bm-persona/Libraries/LibraryViewController.swift
@@ -153,13 +153,3 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
     }
     
 }
-
-extension LibraryViewController {
-    func handlePanGesture(gesture: UIPanGestureRecognizer) {
-        let state = handlePan(gesture: gesture)
-        if state == .hidden {
-            // get rid of the top detail drawer if user sends it to bottom of screen
-            mainContainer?.dismissTop()
-        }
-    }
-}

--- a/bm-persona/Map/MapViewController.swift
+++ b/bm-persona/Map/MapViewController.swift
@@ -311,9 +311,9 @@ extension MapViewController: SearchResultsViewDelegate {
                                                       latitudinalMeters: regionRadius * 2.0, longitudinalMeters: regionRadius * 2.0)
             mapView.setRegion(coordinateRegion, animated: true)
             let item = placemark.item
-            if item != nil {
-                let annotation = SearchAnnotation(item: item!, location: location.coordinate)
-                annotation.title = item!.searchName
+            if let item = item {
+                let annotation = SearchAnnotation(item: item, location: location.coordinate)
+                annotation.title = item.searchName
                 searchAnnotation = annotation
                 // add and select marker for search item, remove resource view if any
                 mapView.addAnnotation(annotation)
@@ -322,22 +322,12 @@ extension MapViewController: SearchResultsViewDelegate {
                     mapView.deselectAnnotation(markerDetail.marker, animated: true)
                 }
                 // if the new search item has a detail view: remove the old detail view, show the new one
-                if let hall = item as? DiningHall {
-                    if drawerViewController != nil {
-                        mainContainer?.dismissTop(showNext: false)
-                    }
-                    presentDetail(type: DiningHall.self, item: hall, containingVC: mainContainer!, position: .middle)
-                } else if let lib = item as? Library {
-                    if drawerViewController != nil {
-                        mainContainer?.dismissTop(showNext: false)
-                    }
-                    presentDetail(type: Library.self, item: lib, containingVC: mainContainer!, position: .middle)
-                } else {
-                    /* if the search item isn't a dining hall or library, don't show any detail view
-                     still dismiss any past detail views and show the drawer underneath */
-                    if drawerViewController != nil {
-                        mainContainer?.dismissTop()
-                    }
+                // otherwise: still dismiss any past detail views and show the drawer underneath
+                if drawerViewController != nil {
+                    mainContainer?.dismissTop()
+                }
+                if let type = type(of: item) as? AnyClass {
+                    presentDetail(type: type, item: item, containingVC: mainContainer!, position: .middle)
                 }
             }
         }

--- a/bm-persona/Resources/ResourceDetailViewController.swift
+++ b/bm-persona/Resources/ResourceDetailViewController.swift
@@ -17,6 +17,10 @@ class ResourceDetailViewController: SearchDrawerViewController {
     var overviewCard: OverviewCardView!
     var openTimesCard: OpenTimesCardView?
 
+    override var upperLimitState: DrawerState? {
+        return openTimesCard == nil ? .middle : nil
+    }
+
     /// Boolean indicating whether this view is presented modally or through a drawer.
     private var presentedModally: Bool = false
 

--- a/bm-persona/Resources/ResourceDetailViewController.swift
+++ b/bm-persona/Resources/ResourceDetailViewController.swift
@@ -76,7 +76,7 @@ extension ResourceDetailViewController {
         guard resource.weeklyHours != nil else { return }
         openTimesCard = OpenTimesCardView(item: resource, animationView: scrollingStackView, toggleAction: { open in
             if open, self.currState != .full {
-                self.delegate.moveDrawer(to: .full, duration: 0.6)
+                self.delegate?.moveDrawer(to: .full, duration: 0.6)
             }
         })
         guard let openTimesCard = self.openTimesCard else { return }

--- a/bm-persona/Resources/ResourceDetailViewController.swift
+++ b/bm-persona/Resources/ResourceDetailViewController.swift
@@ -1,0 +1,89 @@
+//
+//  ResourceDetailViewController.swift
+//  bm-persona
+//
+//  Created by Kevin Hu on 9/5/20.
+//  Copyright © 2020 RJ Pimentel. All rights reserved.
+//
+
+import UIKit
+
+fileprivate let kViewMargin: CGFloat = 16
+
+class ResourceDetailViewController: SearchDrawerViewController {
+
+    var resource: Resource!
+
+    var overviewCard: OverviewCardView!
+    var openTimesCard: OpenTimesCardView?
+
+    /// Boolean indicating whether this view is presented modally or through a drawer.
+    private var presentedModally: Bool = false
+
+    init(presentedModally: Bool = false) {
+        self.presentedModally = presentedModally
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setUpScrollView()
+        setUpOverviewCard()
+        setUpOpenTimesCard()
+    }
+
+    override func setupGestures() {
+        // No need to have gestures if this is not in a drawer.
+        if presentedModally { return }
+        super.setupGestures()
+    }
+
+    override func viewDidLayoutSubviews() {
+        /* Set the bottom cutoff point for when the drawer appears
+        The "middle" position for the view will show everything in the overview card
+        When collapsible open time card is added, change this to show that card as well. */
+        middleCutoffPosition = (openTimesCard?.frame.maxY ?? overviewCard.frame.maxY) + scrollingStackView.yOffset + 8
+    }
+
+    var scrollingStackView: ScrollingStackView = {
+        let scrollingStackView = ScrollingStackView()
+        scrollingStackView.scrollView.showsVerticalScrollIndicator = false
+        scrollingStackView.stackView.spacing = kViewMargin
+        return scrollingStackView
+    }()
+}
+
+// MARK: - View
+
+extension ResourceDetailViewController {
+
+    func setUpOverviewCard() {
+        overviewCard = OverviewCardView(item: resource, excludedElements: [.openTimes])
+        overviewCard.heightAnchor.constraint(equalToConstant: 200).isActive = true
+        scrollingStackView.stackView.addArrangedSubview(overviewCard)
+    }
+
+    func setUpOpenTimesCard() {
+        guard resource.weeklyHours != nil else { return }
+        openTimesCard = OpenTimesCardView(item: resource, animationView: scrollingStackView, toggleAction: { open in
+            if open, self.currState != .full {
+                self.delegate.moveDrawer(to: .full, duration: 0.6)
+            }
+        })
+        guard let openTimesCard = self.openTimesCard else { return }
+        scrollingStackView.stackView.addArrangedSubview(openTimesCard)
+    }
+
+    func setUpScrollView() {
+        view.addSubview(scrollingStackView)
+        scrollingStackView.topAnchor.constraint(equalTo: barView.bottomAnchor, constant: kViewMargin).isActive = true
+        scrollingStackView.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
+        scrollingStackView.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
+        scrollingStackView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
+    }
+}

--- a/bm-persona/Resources/ResourcesViewController.swift
+++ b/bm-persona/Resources/ResourcesViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-fileprivate let kViewMargin: CGFloat = 128
+fileprivate let kViewMargin: CGFloat = 16
 
 class ResourcesViewController: UIViewController {
     private var resourcesLabel: UILabel!
@@ -39,23 +39,23 @@ class ResourcesViewController: UIViewController {
 
 extension ResourcesViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return resourceEntries.count
+        return resourcesTable.filteredData.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ResourceTableViewCell()
-        cell.cellConfigure(entry: resourceEntries[indexPath.row])
-        return cell
+        if let cell = tableView.dequeueReusableCell(withIdentifier: ResourceTableViewCell.kCellIdentifier, for: indexPath) as? ResourceTableViewCell {
+            cell.cellConfigure(entry: resourcesTable.filteredData[indexPath.row])
+            return cell
+        }
+        return UITableViewCell()
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let vc = ResourceDetailViewController(presentedModally: true)
+        vc.resource = resourcesTable.filteredData[indexPath.row]
+        present(vc, animated: true)
         tableView.deselectRow(at: indexPath, animated: true)
     }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 103
-    }
-    
 }
 
 extension ResourcesViewController {
@@ -75,25 +75,24 @@ extension ResourcesViewController {
         card.layoutMargins = kCardPadding
         view.addSubview(card)
         card.translatesAutoresizingMaskIntoConstraints = false
-        card.topAnchor.constraint(equalTo: view.topAnchor, constant: kViewMargin).isActive = true
+        card.topAnchor.constraint(equalTo: resourcesLabel.bottomAnchor, constant: kViewMargin).isActive = true
         card.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
         card.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
         card.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
         
-        let filters = [Filter<Resource>(label: "Open", filter: {resource in resource.isOpen ?? false})]
+        let filters = [
+            Filter<Resource>(label: "Nearby", filter: Resource.locationFilter(by: Resource.nearbyDistance)),
+            Filter<Resource>(label: "Open", filter: {resource in resource.isOpen ?? false})
+        ]
         resourcesTable = FilterTableView(frame: .zero, filters: filters)
-        resourcesTable.tableView.allowsSelection = false
+        resourcesTable.tableView.register(ResourceTableViewCell.self, forCellReuseIdentifier: ResourceTableViewCell.kCellIdentifier)
+        resourcesTable.tableView.rowHeight = 103
         
         resourcesTable.tableView.delegate = self
         resourcesTable.tableView.dataSource = self
         
         resourcesTable.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(resourcesTable)
-        
-//        table.layer.masksToBounds = true
-//        table.contentInset = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
-//        table.setContentOffset(CGPoint(x: 0, y: -5), animated: false)
-//        table.contentInsetAdjustmentBehavior = .never
         
         resourcesTable.tableView.separatorStyle = .none
         resourcesTable.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor).isActive = true

--- a/bm-persona/Utils/Date+Extension.swift
+++ b/bm-persona/Utils/Date+Extension.swift
@@ -33,6 +33,12 @@ extension Date {
         }
         return calendar.nextDate(after: calendar.startOfDay(for: Date()), matching: components, matchingPolicy: .nextTime, repeatedTimePolicy: .first, direction: .forward)
     }
+
+    // Returns a date with this date's hour and minute component only.
+    func timeOnly() -> Date? {
+        let calendar = Calendar.current
+        return calendar.date(from: calendar.dateComponents([.hour, .minute], from: self))
+    }
     
     // Returns the weekday as an integer (0 -> Sunday, 6 -> Saturday)
     func weekday() -> Int {

--- a/bm-persona/Utils/WeeklyHours.swift
+++ b/bm-persona/Utils/WeeklyHours.swift
@@ -21,6 +21,11 @@ typealias WeeklyHoursType = [DayOfWeek: DailyHoursType]
 class WeeklyHours {
     
     private var weeklyHours: WeeklyHoursType
+
+    /// Boolean indicating if the object contains no intervals.
+    open var isEmpty: Bool {
+        return weeklyHours.isEmpty
+    }
     
     init() {
         self.weeklyHours = [:]


### PR DESCRIPTION
- Adds `ScrollingStackView`, a view with a `UIStackView` that scrolls vertically once the stack view contents exceed the bounds of the view.
  - Changes `LibraryDetailViewController` to use this new view and simplify some code
- Adds detail views for Gyms and Campus Resources using `ScrollingStackView`.
  - For Campus Resources, since these are on a separate tab, these present modally when a resource cell is clicked (instead of being brought up in a drawer).
- Shows detail view for Gyms and Campus Resources when searched.

Other Changes
- Fixes filters on Resources tab not doing anything.
- Adds "Nearby" filter to Resources tab.

There's still a fair amount of repeated code between all these detail views (all of them create a `ScrollingStackView` and add an overview card, for example), wondering if y'all think I should unify them some more (e.g. with a general `DetailViewController`), or if we should keep them separate for potential divergences in the future.