### PR TITLE
Remove "Recommended" Label

### DIFF
--- a/bm-persona/Common/FilterTableView/FilterTableView.swift
+++ b/bm-persona/Common/FilterTableView/FilterTableView.swift
@@ -23,17 +23,17 @@ class FilterTableView<T>: UIView {
     var defaultSort: ((T, T) -> Bool)
     
     var isInitialSetup = true
-    
-    override func layoutSubviews() {
+
+    func setupSubviews() {
         self.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         self.addSubview(filter)
-        
+
         filter.translatesAutoresizingMaskIntoConstraints = false
         filter.leftAnchor.constraint(equalTo: self.layoutMarginsGuide.leftAnchor).isActive = true
         filter.rightAnchor.constraint(equalTo: self.layoutMarginsGuide.rightAnchor).isActive = true
         filter.topAnchor.constraint(equalTo: self.layoutMarginsGuide.topAnchor).isActive = true
         filter.heightAnchor.constraint(equalToConstant: FilterViewCell.kCellSize.height).isActive = true
-        
+
         self.addSubview(tableView)
         tableView.separatorStyle = UITableViewCell.SeparatorStyle.none
         tableView.translatesAutoresizingMaskIntoConstraints = false
@@ -52,6 +52,7 @@ class FilterTableView<T>: UIView {
     init(frame: CGRect, tableFunctions: [TableFunction], defaultSort: @escaping ((T, T) -> Bool), initialSelectedIndices: [Int] = []) {
         self.defaultSort = defaultSort
         super.init(frame: frame)
+        self.setupSubviews()
 
         missingView = MissingDataView(parentView: tableView, text: "No items found")
         self.tableFunctions = tableFunctions

--- a/bm-persona/Common/FilterTableView/FilterTableViewCell.swift
+++ b/bm-persona/Common/FilterTableView/FilterTableViewCell.swift
@@ -51,8 +51,7 @@ class FilterTableViewCell: UITableViewCell {
         
         recLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor).isActive = true
         recLabel.leftAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leftAnchor).isActive = true
-        
-        nameLabel.heightAnchor.constraint(equalToConstant: 65).isActive = true
+
         nameLabel.leftAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leftAnchor).isActive = true
         nameLabel.topAnchor.constraint(equalTo: recLabel.layoutMarginsGuide.bottomAnchor, constant: 5).isActive = true
         nameLabel.rightAnchor.constraint(equalTo: cellImage.leftAnchor, constant: -10).isActive = true
@@ -63,7 +62,7 @@ class FilterTableViewCell: UITableViewCell {
         cellImage.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.35).isActive = true
         
         distanceOccupancyStack.rightAnchor.constraint(lessThanOrEqualTo: cellImage.leftAnchor, constant: -10).isActive = true
-        distanceOccupancyStack.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 5).isActive = true
+        distanceOccupancyStack.topAnchor.constraint(greaterThanOrEqualTo: nameLabel.bottomAnchor, constant: 5).isActive = true
         distanceOccupancyStack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor, constant: -5).isActive = true
         distanceOccupancyStack.leftAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leftAnchor).isActive = true
     }
@@ -78,6 +77,7 @@ class FilterTableViewCell: UITableViewCell {
             distanceOccupancyStack.addArrangedSubview(locationDetailView)
         }
         self.recLabel.text = "Recommended"
+        self.recLabel.isHidden = true
         
         if let itemWithOccupancy = item as? HasOccupancy, let status = itemWithOccupancy.getCurrentOccupancyStatus(isOpen: (item as? HasOpenTimes)?.isOpen) {
             distanceOccupancyStack.addArrangedSubview(IconPairView(icon: chairImage, iconHeight: 16, iconWidth: 28, attachedView: status.badge()))


### PR DESCRIPTION
Removes "Recommended" label in top right of cells for Libraries, Dining Halls, and Gyms. Leaves space for the label (only hides it), and top-aligns the name text.
<img width="559" alt="Screen Shot 2020-09-12 at 4 02 31 PM" src="https://user-images.githubusercontent.com/41145903/93006530-15ab8480-f512-11ea-81e1-5391285c6334.png">
<img width="559" alt="Screen Shot 2020-09-12 at 4 02 29 PM" src="https://user-images.githubusercontent.com/41145903/93006531-19d7a200-f512-11ea-9dd2-21230277bd93.png">


Also fixes issue where Resource cells were taller than expected.