### PR TITLE
Hotfix: Dining Menu Crash

### DIFF
--- a/bm-persona/Dining/DiningDetailViewController.swift
+++ b/bm-persona/Dining/DiningDetailViewController.swift
@@ -142,7 +142,6 @@ extension DiningDetailViewController: TabBarControlDelegate {
         guard let control = self.control else { return }
         control.index = value
         self.menuView.setData(data: meals[mealNames[control.index]]!)
-        self.menuView.tableView.reloadData()
         self.menuView.filter.deselectAllItems()
         self.menuView.update()
     }

--- a/bm-persona/Dining/DiningDetailViewController.swift
+++ b/bm-persona/Dining/DiningDetailViewController.swift
@@ -153,7 +153,8 @@ extension DiningDetailViewController: UITableViewDelegate, UITableViewDataSource
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if let cell = tableView.dequeueReusableCell(withIdentifier: DiningMenuCell.kCellIdentifier, for: indexPath) as? DiningMenuCell {
+        if let cell = tableView.dequeueReusableCell(withIdentifier: DiningMenuCell.kCellIdentifier, for: indexPath) as? DiningMenuCell,
+            indexPath.row < self.menuView.filteredData.count {
             let item: DiningItem = self.menuView.filteredData[indexPath.row]
             cell.nameLabel.text = item.name
             cell.item = item


### PR DESCRIPTION
Quickly switching between dining menus (e.g. "Lunch" to "Dinner" and back) sometimes raises an index out of bounds exception. Removing a `reloadData()` call before `menuView.update()` appears to have fixed the issue, but I also added a check before indexing into the array, just to be safe.