### PR TITLE
Calendar Tab View Height

### DIFF
--- a/berkeley-mobile/Calendar/AcademicCalendarViewController.swift
+++ b/berkeley-mobile/Calendar/AcademicCalendarViewController.swift
@@ -175,7 +175,7 @@ extension AcademicCalendarViewController {
         card.layoutMargins = kCardPadding
         scrollingStackView.stackView.addArrangedSubview(card)
         card.translatesAutoresizingMaskIntoConstraints = false
-        card.heightAnchor.constraint(equalTo: view.layoutMarginsGuide.heightAnchor, constant: -view.layoutMargins.top).isActive = true
+        card.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
 
         let tableView = UITableView()
         tableView.register(EventTableViewCell.self, forCellReuseIdentifier: EventTableViewCell.kCellIdentifier)

--- a/berkeley-mobile/Calendar/CampusCalendarViewController.swift
+++ b/berkeley-mobile/Calendar/CampusCalendarViewController.swift
@@ -176,7 +176,7 @@ extension CampusCalendarViewController {
         card.layoutMargins = kCardPadding
         scrollingStackView.stackView.addArrangedSubview(card)
         card.translatesAutoresizingMaskIntoConstraints = false
-        card.heightAnchor.constraint(equalTo: view.layoutMarginsGuide.heightAnchor, constant: -view.layoutMargins.top).isActive = true
+        card.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
 
         let table = UITableView()
         table.register(EventTableViewCell.self, forCellReuseIdentifier: EventTableViewCell.kCellIdentifier)


### PR DESCRIPTION
Reduces the height of the tableviews in the Calendar tab to simplify user flow and make the view more intuitive.
<img width="559" alt="Screen Shot 2020-09-27 at 10 26 49 PM" src="https://user-images.githubusercontent.com/41145903/94393859-d899e180-0110-11eb-917f-0766fedb86f0.png">
