### PR TITLE
Description Card

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		01B2502D2516C42E00CBA459 /* AcademicEventsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B2502C2516C42E00CBA459 /* AcademicEventsDataSource.swift */; };
 		01B2502F2516C45800CBA459 /* AcademicCalendarEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B2502E2516C45800CBA459 /* AcademicCalendarEntry.swift */; };
 		01BC8EB024E8C3E3005B4969 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BC8EAF24E8C3E3005B4969 /* DetailView.swift */; };
+		01C75E2E25292E5B00C25A32 /* DescriptionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C75E2D25292E5B00C25A32 /* DescriptionCardView.swift */; };
 		01D11B8E2504453B00BDF660 /* ScrollingStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B8D2504453B00BDF660 /* ScrollingStackView.swift */; };
 		01D11B902504560700BDF660 /* GymDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B8F2504560700BDF660 /* GymDetailViewController.swift */; };
 		01D11B9225045FC900BDF660 /* ResourceDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B9125045FC900BDF660 /* ResourceDetailViewController.swift */; };
@@ -149,6 +150,7 @@
 		01B2502C2516C42E00CBA459 /* AcademicEventsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademicEventsDataSource.swift; sourceTree = "<group>"; };
 		01B2502E2516C45800CBA459 /* AcademicCalendarEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademicCalendarEntry.swift; sourceTree = "<group>"; };
 		01BC8EAF24E8C3E3005B4969 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		01C75E2D25292E5B00C25A32 /* DescriptionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionCardView.swift; sourceTree = "<group>"; };
 		01D11B8D2504453B00BDF660 /* ScrollingStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingStackView.swift; sourceTree = "<group>"; };
 		01D11B8F2504560700BDF660 /* GymDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymDetailViewController.swift; sourceTree = "<group>"; };
 		01D11B9125045FC900BDF660 /* ResourceDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDetailViewController.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 				29345E2624A7E76300859A88 /* OverviewCardView.swift */,
 				2913595824B13DF200DE9AD6 /* OpenTimesCardView.swift */,
 				29387E9C24BBBE8E00070BCE /* OccupancyGraphCardView.swift */,
+				01C75E2D25292E5B00C25A32 /* DescriptionCardView.swift */,
 			);
 			path = DetailView;
 			sourceTree = "<group>";
@@ -902,6 +905,7 @@
 				29345E2924A7E7AC00859A88 /* HasPhoneNumber.swift in Sources */,
 				130FA59E243B1243005DC752 /* DiningRestriction.swift in Sources */,
 				556CCD2D23E79EC100F41BF9 /* TabBarController.swift in Sources */,
+				01C75E2E25292E5B00C25A32 /* DescriptionCardView.swift in Sources */,
 				13B39A8D23E689BC0039FBA2 /* DataSource.swift in Sources */,
 				299ACFB2244A5A15000F3E86 /* Occupancy.swift in Sources */,
 				133864AD2404E858001F9048 /* CampusCalendarDataSource.swift in Sources */,

--- a/berkeley-mobile/Common/DetailView/DescriptionCardView.swift
+++ b/berkeley-mobile/Common/DetailView/DescriptionCardView.swift
@@ -1,0 +1,56 @@
+//
+//  DescriptionCardView.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 10/3/20.
+//  Copyright © 2020 ASUC OCTO. All rights reserved.
+//
+
+import UIKit
+
+fileprivate let kViewMargin: CGFloat = 21
+
+/// A card with a label displaying the description for some resource.
+class DescriptionCardView: CardView {
+
+    /// A label for the bolded title of the card ("Description").
+    private var cardTitle: UILabel!
+
+    /// The label displaying the description.
+    private var descriptionLabel: UILabel!
+
+    public init?(description: String?) {
+        guard let description = description else { return nil }
+        super.init(frame: .zero)
+
+        // Default padding for the card
+        layoutMargins = UIEdgeInsets(top: 31, left: 31, bottom: 31, right: 31)
+
+        cardTitle = UILabel()
+        cardTitle.font = Font.bold(24)
+        cardTitle.text = "Description"
+        addSubview(cardTitle)
+
+        cardTitle.translatesAutoresizingMaskIntoConstraints = false
+        cardTitle.leftAnchor.constraint(equalTo: layoutMarginsGuide.leftAnchor).isActive = true
+        cardTitle.rightAnchor.constraint(equalTo: layoutMarginsGuide.rightAnchor).isActive = true
+        cardTitle.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor).isActive = true
+
+        descriptionLabel = UILabel()
+        descriptionLabel.font = Font.regular(12)
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.text = description
+        addSubview(descriptionLabel)
+
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        descriptionLabel.topAnchor.constraint(equalTo: cardTitle.bottomAnchor, constant: kViewMargin).isActive = true
+        descriptionLabel.leftAnchor.constraint(equalTo: layoutMarginsGuide.leftAnchor).isActive = true
+        descriptionLabel.rightAnchor.constraint(equalTo: layoutMarginsGuide.rightAnchor).isActive = true
+        descriptionLabel.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor).isActive = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/berkeley-mobile/Common/DetailView/DescriptionCardView.swift
+++ b/berkeley-mobile/Common/DetailView/DescriptionCardView.swift
@@ -8,7 +8,8 @@
 
 import UIKit
 
-fileprivate let kViewMargin: CGFloat = 21
+fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+fileprivate let kViewMargin: CGFloat = 16
 
 /// A card with a label displaying the description for some resource.
 class DescriptionCardView: CardView {
@@ -24,10 +25,10 @@ class DescriptionCardView: CardView {
         super.init(frame: .zero)
 
         // Default padding for the card
-        layoutMargins = UIEdgeInsets(top: 31, left: 31, bottom: 31, right: 31)
+        layoutMargins = kCardPadding
 
         cardTitle = UILabel()
-        cardTitle.font = Font.bold(24)
+        cardTitle.font = Font.bold(16)
         cardTitle.text = "Description"
         addSubview(cardTitle)
 

--- a/berkeley-mobile/Data/ItemProtocols/SearchItem.swift
+++ b/berkeley-mobile/Data/ItemProtocols/SearchItem.swift
@@ -13,7 +13,6 @@ protocol SearchItem: HasName {
     var searchName: String { get }
     var location: (Double, Double) { get }
     var locationName: String { get }
-    var description: String { get }
     // icon to display on when pin is dropped on map search
     var icon: UIImage? { get }
 }

--- a/berkeley-mobile/Dining/DiningDataSource/DiningLocation.swift
+++ b/berkeley-mobile/Dining/DiningDataSource/DiningLocation.swift
@@ -25,10 +25,6 @@ class DiningLocation: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasI
         return address ?? "Berkeley, CA"
     }
     
-    var description: String {
-        return ""
-    }
-    
     let name: String
     let imageURL: URL?
     let address: String?

--- a/berkeley-mobile/Fitness/GymDataSource/Gym.swift
+++ b/berkeley-mobile/Fitness/GymDataSource/Gym.swift
@@ -24,10 +24,6 @@ class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOp
         return "Berkeley, CA"
     }
     
-    var description: String {
-        return ""
-    }
-    
     var image: UIImage?
     
     static func displayName(pluralized: Bool) -> String {
@@ -36,6 +32,7 @@ class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOp
     
     let name: String
     let imageURL: URL?
+    let description: String?
     
     var isFavorited: Bool = false
     
@@ -48,8 +45,9 @@ class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOp
     var latitude: Double?
     var longitude: Double?
     
-    init(name: String, address: String?, phoneNumber: String?, imageLink: String?, weeklyHours: WeeklyHours?) {
+    init(name: String, description: String?, address: String?, phoneNumber: String?, imageLink: String?, weeklyHours: WeeklyHours?) {
         self.address = address
+        self.description = description
         self.phoneNumber = phoneNumber
         self.weeklyHours = weeklyHours
         

--- a/berkeley-mobile/Fitness/GymDataSource/GymDataSource.swift
+++ b/berkeley-mobile/Fitness/GymDataSource/GymDataSource.swift
@@ -37,6 +37,7 @@ class GymDataSource: DataSource
         let weeklyHours = Gym.parseWeeklyHours(dict: dict["open_close_array"] as? [[String: Any]])
         
         let gym = Gym(name: dict["name"] as? String ?? "Unnamed",
+                      description: dict["description"] as? String,
                       address: dict["address"] as? String,
                       phoneNumber: dict["phone"] as? String,
                       imageLink: dict["picture"] as? String,

--- a/berkeley-mobile/Fitness/GymDetailViewController.swift
+++ b/berkeley-mobile/Fitness/GymDetailViewController.swift
@@ -17,9 +17,12 @@ class GymDetailViewController: SearchDrawerViewController {
     var overviewCard: OverviewCardView!
     var openTimesCard: OpenTimesCardView?
     var occupancyCard: OccupancyGraphCardView?
+    var descriptionCard: DescriptionCardView?
 
     override var upperLimitState: DrawerState? {
-        return openTimesCard == nil && occupancyCard == nil ? .middle : nil
+        return openTimesCard == nil &&
+               occupancyCard == nil &&
+               descriptionCard == nil ? .middle : nil
     }
 
     override func viewDidLoad() {
@@ -29,6 +32,7 @@ class GymDetailViewController: SearchDrawerViewController {
         setUpOverviewCard()
         setUpOpenTimesCard()
         setUpOccupancyCard()
+        setupDescriptionCard()
     }
 
     override func viewDidLayoutSubviews() {
@@ -72,6 +76,12 @@ extension GymDetailViewController {
         occupancyCard = OccupancyGraphCardView(occupancy: occupancy, isOpen: gym.isOpen)
         guard let occupancyCard = self.occupancyCard else { return }
         scrollingStackView.stackView.addArrangedSubview(occupancyCard)
+    }
+
+    func setupDescriptionCard() {
+        descriptionCard = DescriptionCardView(description: gym.description)
+        guard let descriptionCard = descriptionCard else { return }
+        scrollingStackView.stackView.addArrangedSubview(descriptionCard)
     }
 
     func setUpScrollView() {

--- a/berkeley-mobile/Libraries/LibraryDataSource/Library.swift
+++ b/berkeley-mobile/Libraries/LibraryDataSource/Library.swift
@@ -29,15 +29,12 @@ class Library: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, H
         return "Librar" + (pluralized ? "ies" : "y")
     }
     
-    var description: String {
-        return ""
-    }
-    
     let name: String
     let imageURL: URL?
     
     var isFavorited: Bool = false
-    
+
+    var description: String?
     let address: String?
     let phoneNumber: String?
     let weeklyHours: WeeklyHours?
@@ -46,7 +43,8 @@ class Library: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, H
     var latitude: Double?
     var longitude: Double?
     
-    init(name: String, address: String?, phoneNumber: String?, weeklyHours: WeeklyHours?, weeklyByAppointment:[Bool], imageLink: String?, latitude: Double?, longitude: Double?) {
+    init(name: String, description: String?, address: String?, phoneNumber: String?, weeklyHours: WeeklyHours?, weeklyByAppointment:[Bool], imageLink: String?, latitude: Double?, longitude: Double?) {
+        self.description = description
         self.address = address
         self.phoneNumber = phoneNumber
         self.weeklyHours = weeklyHours

--- a/berkeley-mobile/Libraries/LibraryDataSource/LibraryDataSource.swift
+++ b/berkeley-mobile/Libraries/LibraryDataSource/LibraryDataSource.swift
@@ -50,6 +50,7 @@ class LibraryDataSource: DataSource {
         let weeklyHours = Library.parseWeeklyHours(dict: dict["open_close_array"] as? [[String: Any]])
         #endif
         let library = Library(name: dict["name"] as? String ?? "Unnamed",
+                              description: dict["description"] as? String,
                               address: dict["address"] as? String,
                               phoneNumber: dict["phone"] as? String,
                               weeklyHours: weeklyHours,

--- a/berkeley-mobile/Libraries/LibraryDetailViewController.swift
+++ b/berkeley-mobile/Libraries/LibraryDetailViewController.swift
@@ -26,8 +26,8 @@ class LibraryDetailViewController: SearchDrawerViewController {
         setUpOverviewCard()
         setUpOpenTimesCard()
         setUpOccupancyCard()
-        setupDescriptionCard()
         setUpBookButton()
+        setupDescriptionCard()
     }
     
     override func viewDidLayoutSubviews() {

--- a/berkeley-mobile/Libraries/LibraryDetailViewController.swift
+++ b/berkeley-mobile/Libraries/LibraryDetailViewController.swift
@@ -26,6 +26,7 @@ class LibraryDetailViewController: SearchDrawerViewController {
         setUpOverviewCard()
         setUpOpenTimesCard()
         setUpOccupancyCard()
+        setupDescriptionCard()
         setUpBookButton()
     }
     
@@ -92,6 +93,11 @@ extension LibraryDetailViewController {
         occupancyCard = OccupancyGraphCardView(occupancy: occupancy, isOpen: library.isOpen)
         guard let occupancyCard = self.occupancyCard else { return }
         scrollingStackView.stackView.addArrangedSubview(occupancyCard)
+    }
+
+    func setupDescriptionCard() {
+        guard let descriptionCard = DescriptionCardView(description: library.description) else { return }
+        scrollingStackView.stackView.addArrangedSubview(descriptionCard)
     }
     
     func setUpBookButton() {

--- a/berkeley-mobile/Resources/ResourceDetailViewController.swift
+++ b/berkeley-mobile/Resources/ResourceDetailViewController.swift
@@ -16,9 +16,11 @@ class ResourceDetailViewController: SearchDrawerViewController {
 
     var overviewCard: OverviewCardView!
     var openTimesCard: OpenTimesCardView?
+    var descriptionCard: DescriptionCardView?
 
     override var upperLimitState: DrawerState? {
-        return openTimesCard == nil ? .middle : nil
+        return openTimesCard == nil &&
+               descriptionCard == nil ? .middle : nil
     }
 
     /// Boolean indicating whether this view is presented modally or through a drawer.
@@ -39,6 +41,7 @@ class ResourceDetailViewController: SearchDrawerViewController {
         setUpScrollView()
         setUpOverviewCard()
         setUpOpenTimesCard()
+        setupDescriptionCard()
     }
 
     override func setupGestures() {
@@ -81,6 +84,12 @@ extension ResourceDetailViewController {
         })
         guard let openTimesCard = self.openTimesCard else { return }
         scrollingStackView.stackView.addArrangedSubview(openTimesCard)
+    }
+
+    func setupDescriptionCard() {
+        descriptionCard = DescriptionCardView(description: resource.description)
+        guard let descriptionCard = descriptionCard else { return }
+        scrollingStackView.stackView.addArrangedSubview(descriptionCard)
     }
 
     func setUpScrollView() {

--- a/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
+++ b/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
@@ -24,16 +24,12 @@ class Resource: SearchItem, HasLocation, HasOpenTimes {
         return self.address ?? "Berkeley, CA"
     }
     
-    var description: String {
-        return self.desc
-    }
-    
     var latitude: Double?
     var longitude: Double?
     
     let name: String
     let address: String?
-    let desc: String
+    let description: String?
     var weeklyHours: WeeklyHours?
     
     init(name: String, address: String?, latitude: Double?, longitude: Double?, description: String?, hours: WeeklyHours?) {
@@ -41,7 +37,7 @@ class Resource: SearchItem, HasLocation, HasOpenTimes {
         self.address = address
         self.latitude = latitude
         self.longitude = longitude
-        self.desc = description ?? ""
+        self.description = description
         self.weeklyHours = hours
     }
 }


### PR DESCRIPTION
Adds additional card when viewing the details for Libraries, Gyms, and Campus Resources that displays a textual description of the resource. This card is inserted at the bottom of the page (or, in the case for Library, above the "Book a Study Room" button).
- Adds `DescriptionCardView`, a simple `CardView` subclass that has a label for a card title and a label to display some descriptive text, which syncs up presentation of the field across the different item types
- Adds optional `description` field to the models: `Library`, `Gym`, `Resource`
- Removes `description` parameter from the `SearchItem` protocol

<img width="584" alt="Screen Shot 2020-10-10 at 12 32 45 AM" src="https://user-images.githubusercontent.com/41145903/95649070-97022280-0a90-11eb-8c18-3cf50b73d376.png">

### Feedback Request

I used the mock-ups for the description card from the events page, but this looks a bit strange in the context of the detail pages for the Libraries + whatnot. My main complaint is with the card title:
- The title is a very large font, bigger than the title for the "Occupancy" card, and in some cases, the name of the item in the Overview card
- Is a title even necessary? Especially for items with shorter descriptions, it seems like we might be better off just displaying the description with no title:
<img width="584" alt="Screen Shot 2020-10-10 at 12 40 34 AM" src="https://user-images.githubusercontent.com/41145903/95649239-640c5e80-0a91-11eb-8b00-19a0a97a8d71.png">

Also curious to hear any thoughts about the placement of the card within the page. I feel it might be better to have it above the occupancy card. What do y'all think?