### PR TITLE
Adds "Learn More" button for Fitness location sites

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		016A56D6251AD38F00531A12 /* CalendarEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A56D5251AD38F00531A12 /* CalendarEvent.swift */; };
 		016A56D8251C930D00531A12 /* AppDelegate+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A56D7251C930D00531A12 /* AppDelegate+Migration.swift */; };
 		017C0B26251018BA00BFA80A /* Colors+MapMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */; };
+		018B982625327358004C3B26 /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982525327358004C3B26 /* ActionButton.swift */; };
+		018B982825328200004C3B26 /* Colors+ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982725328200004C3B26 /* Colors+ActionButton.swift */; };
 		01B250282516AD4F00CBA459 /* IconPairView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B250272516AD4F00CBA459 /* IconPairView.swift */; };
 		01B2502D2516C42E00CBA459 /* AcademicEventsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B2502C2516C42E00CBA459 /* AcademicEventsDataSource.swift */; };
 		01B2502F2516C45800CBA459 /* AcademicCalendarEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B2502E2516C45800CBA459 /* AcademicCalendarEntry.swift */; };
@@ -145,6 +147,8 @@
 		016A56D5251AD38F00531A12 /* CalendarEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEvent.swift; sourceTree = "<group>"; };
 		016A56D7251C930D00531A12 /* AppDelegate+Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Migration.swift"; sourceTree = "<group>"; };
 		017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+MapMarker.swift"; sourceTree = "<group>"; };
+		018B982525327358004C3B26 /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
+		018B982725328200004C3B26 /* Colors+ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+ActionButton.swift"; sourceTree = "<group>"; };
 		01B250272516AD4F00CBA459 /* IconPairView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconPairView.swift; sourceTree = "<group>"; };
 		01B2502C2516C42E00CBA459 /* AcademicEventsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademicEventsDataSource.swift; sourceTree = "<group>"; };
 		01B2502E2516C45800CBA459 /* AcademicCalendarEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademicCalendarEntry.swift; sourceTree = "<group>"; };
@@ -384,6 +388,7 @@
 				55DCF78623722CBD001B01B8 /* Colors.swift */,
 				13491DB9241E23630033F9AB /* Colors+Text.swift */,
 				13491DB5241E21740033F9AB /* Colors+TagView.swift */,
+				018B982725328200004C3B26 /* Colors+ActionButton.swift */,
 				13491DB7241E22130033F9AB /* Colors+Event.swift */,
 				135D7F76243A9BD1003F8BD1 /* Colors+GymClass.swift */,
 				017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */,
@@ -432,6 +437,7 @@
 				1396012E23865E2E005E4788 /* CollectionView */,
 				1396013123865E2E005E4788 /* CardView.swift */,
 				1396013223865E2E005E4788 /* TagView.swift */,
+				018B982525327358004C3B26 /* ActionButton.swift */,
 				01B250272516AD4F00CBA459 /* IconPairView.swift */,
 				554CB99F23F3A83F00BB1715 /* EventTableViewCell.swift */,
 				559AF6DF251EAA2800463E2A /* DetailTapGestureRecognizer.swift */,
@@ -966,6 +972,7 @@
 				29387E9524BBBC1000070BCE /* BarGraph.swift in Sources */,
 				01B2502F2516C45800CBA459 /* AcademicCalendarEntry.swift in Sources */,
 				5516088624392E5100B1E55B /* DiningViewController.swift in Sources */,
+				018B982825328200004C3B26 /* Colors+ActionButton.swift in Sources */,
 				29387E9B24BBBD9D00070BCE /* CALayerExtension.swift in Sources */,
 				1396013323865E2E005E4788 /* CardCollectionView.swift in Sources */,
 				13B39A9A23E6A33C0039FBA2 /* LibraryDataSource.swift in Sources */,
@@ -992,6 +999,7 @@
 				1336A322241D92F700949F32 /* MealType.swift in Sources */,
 				303F6AE1236A931D007E37DD /* SegmentedControl.swift in Sources */,
 				5516088824393F3F00B1E55B /* MissingDataView.swift in Sources */,
+				018B982625327358004C3B26 /* ActionButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/berkeley-mobile/Assets/Colors/Colors+ActionButton.swift
+++ b/berkeley-mobile/Assets/Colors/Colors+ActionButton.swift
@@ -1,0 +1,31 @@
+//
+//  Colors+ActionButton.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 10/10/20.
+//  Copyright © 2020 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension Color {
+    /// Colors for the `ActionButton` class.
+    struct ActionButton {
+
+        /// The color of the text for the button.
+        static var color: UIColor {
+            return UIColor(displayP3Red: 254/255, green: 254/255, blue: 254/255, alpha: 1.0)
+        }
+
+        /// The background color for the button in its default state.
+        static var background: UIColor {
+            return UIColor(displayP3Red: 119/255, green: 154/255, blue: 252/255, alpha: 1.0)
+        }
+
+        /// The background color for the button in its highlighted state.
+        static var highlighted: UIColor {
+            return UIColor(displayP3Red: 96/255, green: 125/255, blue: 204/255, alpha: 1.0)
+        }
+    }
+}

--- a/berkeley-mobile/Common/ActionButton.swift
+++ b/berkeley-mobile/Common/ActionButton.swift
@@ -1,0 +1,47 @@
+//
+//  ActionButton.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 10/10/20.
+//  Copyright © 2020 ASUC OCTO. All rights reserved.
+//
+
+import UIKit
+
+/// The default padding to use for this button.
+fileprivate let kButtonPadding: UIEdgeInsets = UIEdgeInsets(top: 13, left: 16, bottom: 13, right: 16)
+
+/// A stylized button with a background color, rounded corners, and a drop shadow.
+class ActionButton: UIButton {
+
+    override open var isHighlighted: Bool {
+        didSet {
+            backgroundColor = isHighlighted ? Color.ActionButton.highlighted : Color.ActionButton.background
+        }
+    }
+
+    init(title: String, font: UIFont = Font.semibold(12)) {
+        super.init(frame: .zero)
+        contentEdgeInsets = kButtonPadding
+        isHighlighted = false
+
+        // Set rounded corners and drop shadow
+        layer.cornerRadius = 12
+        layer.shadowRadius = 5
+        layer.shadowOpacity = 0.25
+        layer.shadowOffset = .zero
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowPath = UIBezierPath(rect: layer.bounds.insetBy(dx: 4, dy: 4)).cgPath
+
+        // Set title text and font
+        guard let label = titleLabel else { return }
+        setTitle(title, for: .normal)
+        label.font = font
+        label.textColor = Color.ActionButton.color
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/berkeley-mobile/Fitness/FitnessViewController.swift
+++ b/berkeley-mobile/Fitness/FitnessViewController.swift
@@ -266,7 +266,7 @@ extension FitnessViewController {
         gymCard = card
         
         let fitnessLabel = UILabel()
-        fitnessLabel.text = "Fitness Centers"
+        fitnessLabel.text = "Fitness Locations"
         fitnessLabel.font = kHeaderFont
         fitnessLabel.adjustsFontSizeToFitWidth = true
         card.addSubview(fitnessLabel)

--- a/berkeley-mobile/Fitness/GymDataSource/Gym.swift
+++ b/berkeley-mobile/Fitness/GymDataSource/Gym.swift
@@ -10,6 +10,9 @@ import Foundation
 import UIKit
 
 class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOpenTimes, HasOccupancy {
+
+    // MARK: SearchIitem
+
     var icon: UIImage?
     
     var searchName: String {
@@ -27,35 +30,50 @@ class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOp
     var description: String {
         return ""
     }
-    
-    var image: UIImage?
-    
-    static func displayName(pluralized: Bool) -> String {
-        return "Gym" + (pluralized ? "s" : "")
-    }
-    
-    let name: String
-    let imageURL: URL?
-    
-    var isFavorited: Bool = false
-    
-    let address: String?
-    let phoneNumber: String?
-    
-    let weeklyHours: WeeklyHours?
-    var occupancy: Occupancy?
-    
+
+    // MARK: HasLocation
+
     var latitude: Double?
     var longitude: Double?
+    let address: String?
+
+    // MARK: HasImage
+
+    var image: UIImage?
+    let imageURL: URL?
+
+    // MARK: HasPhoneNumber
+
+    let phoneNumber: String?
+
+    // MARK: HasOpenTimes
+
+    let weeklyHours: WeeklyHours?
+
+    // MARK: HasOccupancy
+
+    var occupancy: Occupancy?
+
+    // MARK: CanFavorite
+
+    var isFavorited: Bool = false
+
+    // MARK: Additional Properties
+
+    /// The display-friendly name of this Gym.
+    let name: String
+
+    /// An optional URL linking to a website for this Fitness location.
+    var website: URL?
     
-    init(name: String, address: String?, phoneNumber: String?, imageLink: String?, weeklyHours: WeeklyHours?) {
+    init(name: String, address: String?, phoneNumber: String?, imageLink: String?, weeklyHours: WeeklyHours?, link: String?) {
         self.address = address
         self.phoneNumber = phoneNumber
         self.weeklyHours = weeklyHours
-        
         self.name = name
         self.imageURL = URL(string: imageLink ?? "")
         self.icon = UIImage(named: "Walk")
+        self.website = URL(string: link ?? "")
     }
 
 }

--- a/berkeley-mobile/Fitness/GymDataSource/GymDataSource.swift
+++ b/berkeley-mobile/Fitness/GymDataSource/GymDataSource.swift
@@ -40,7 +40,8 @@ class GymDataSource: DataSource
                       address: dict["address"] as? String,
                       phoneNumber: dict["phone"] as? String,
                       imageLink: dict["picture"] as? String,
-                      weeklyHours: weeklyHours)
+                      weeklyHours: weeklyHours,
+                      link: dict["link"] as? String)
         
         gym.latitude = dict["latitude"] as? Double
         gym.longitude = dict["longitude"] as? Double

--- a/berkeley-mobile/Fitness/GymDetailViewController.swift
+++ b/berkeley-mobile/Fitness/GymDetailViewController.swift
@@ -44,7 +44,7 @@ class GymDetailViewController: SearchDrawerViewController {
     @objc private func moreButtonClicked(sender: UIButton) {
         guard let url = gym.website else { return }
         presentAlertLinkUrl(title: "Are you sure you want to open Safari?",
-                            message: "Berkeley Mobile wants to open this resource's website",
+                            message: "Berkeley Mobile wants to open this fitness location's website",
                             options: "Cancel", "Yes",
                             website_url: url)
     }

--- a/berkeley-mobile/Fitness/GymDetailViewController.swift
+++ b/berkeley-mobile/Fitness/GymDetailViewController.swift
@@ -17,9 +17,10 @@ class GymDetailViewController: SearchDrawerViewController {
     var overviewCard: OverviewCardView!
     var openTimesCard: OpenTimesCardView?
     var occupancyCard: OccupancyGraphCardView?
+    var moreButton: ActionButton?
 
     override var upperLimitState: DrawerState? {
-        return openTimesCard == nil && occupancyCard == nil ? .middle : nil
+        return openTimesCard == nil && occupancyCard == nil && moreButton == nil ? .middle : nil
     }
 
     override func viewDidLoad() {
@@ -29,6 +30,7 @@ class GymDetailViewController: SearchDrawerViewController {
         setUpOverviewCard()
         setUpOpenTimesCard()
         setUpOccupancyCard()
+        setupMoreButton()
     }
 
     override func viewDidLayoutSubviews() {
@@ -36,6 +38,15 @@ class GymDetailViewController: SearchDrawerViewController {
         The "middle" position for the view will show everything in the overview card
         When collapsible open time card is added, change this to show that card as well. */
         middleCutoffPosition = (openTimesCard?.frame.maxY ?? overviewCard.frame.maxY) + scrollingStackView.yOffset + 8
+    }
+
+    /// Opens `gym.website` in Safari. Called as a result of tapping on `moreButton`.
+    @objc private func moreButtonClicked(sender: UIButton) {
+        guard let url = gym.website else { return }
+        presentAlertLinkUrl(title: "Are you sure you want to open Safari?",
+                            message: "Berkeley Mobile wants to open this resource's website",
+                            options: "Cancel", "Yes",
+                            website_url: url)
     }
 
     var scrollingStackView: ScrollingStackView = {
@@ -72,6 +83,14 @@ extension GymDetailViewController {
         occupancyCard = OccupancyGraphCardView(occupancy: occupancy, isOpen: gym.isOpen)
         guard let occupancyCard = self.occupancyCard else { return }
         scrollingStackView.stackView.addArrangedSubview(occupancyCard)
+    }
+
+    func setupMoreButton() {
+        guard gym.website != nil else { return }
+        let button = ActionButton(title: "Learn More")
+        button.addTarget(self, action: #selector(moreButtonClicked), for: .touchUpInside)
+        scrollingStackView.stackView.addArrangedSubview(button)
+        moreButton = button
     }
 
     func setUpScrollView() {

--- a/berkeley-mobile/Libraries/LibraryDetailViewController.swift
+++ b/berkeley-mobile/Libraries/LibraryDetailViewController.swift
@@ -50,20 +50,8 @@ class LibraryDetailViewController: SearchDrawerViewController {
         return scrollingStackView
     }()
 
-    var bookButton: UIButton = {
-        let button = UIButton()
-        button.layoutMargins = kCardPadding
-        button.backgroundColor =  Color.eventAcademic
-        button.layer.cornerRadius = 10
-        button.layer.shadowRadius = 5
-        button.layer.shadowOpacity = 0.25
-        button.layer.shadowOffset = .zero
-        button.layer.shadowColor = UIColor.black.cgColor
-        button.layer.shadowPath = UIBezierPath(rect: button.layer.bounds.insetBy(dx: 4, dy: 4)).cgPath
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("Book a Study Room >", for: .normal)
-        button.titleLabel!.font = Font.semibold(14)
-        button.titleLabel!.textColor = .white
+    var bookButton: ActionButton = {
+        let button = ActionButton(title: "Book a Study Room >")
         button.addTarget(self, action: #selector(bookButtonClicked), for: .touchUpInside)
         return button
     }()
@@ -95,7 +83,6 @@ extension LibraryDetailViewController {
     }
     
     func setUpBookButton() {
-        bookButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
         scrollingStackView.stackView.addArrangedSubview(bookButton)
     }
     

--- a/berkeley-mobile/Libraries/LibraryDetailViewController.swift
+++ b/berkeley-mobile/Libraries/LibraryDetailViewController.swift
@@ -52,7 +52,7 @@ class LibraryDetailViewController: SearchDrawerViewController {
     }()
 
     var bookButton: ActionButton = {
-        let button = ActionButton(title: "Book a Study Room >")
+        let button = ActionButton(title: "Book a Study Room")
         button.addTarget(self, action: #selector(bookButtonClicked), for: .touchUpInside)
         return button
     }()


### PR DESCRIPTION
## Description

Some fitness locations (e.g. hiking paths like Albany Bulb) have associated websites with additional information. Adds a "Learn More" button to the bottom of Gym details that opens these websites in Safari. This button is based off of the "Learn More" button from the event detail mock-up in Figma.
- Moves the implementation of the Library study room button to new `ActionButton`
- Adds optional `website` field to `Gym`
- Adds an action button to the bottom of the stack in `GymDetailViewController`
<img width="559" alt="Screen Shot 2020-10-10 at 5 53 10 PM" src="https://user-images.githubusercontent.com/41145903/95667965-302d4980-0b22-11eb-98dc-0cfc1db7e3ba.png">

## Testing

There is a [known issue](https://www.notion.so/Sprint-Board-iOS-3a44a1f5f7044adab2ea4b7827e7ea5c?p=20204d42576640d7910065740b374129) where the fields in Firestore have trailing / leading whitespace (e.g. the `"link"` field for Gyms is actually `" link"`.

As a workaround until this is fixed, to test this PR, replace the `"link"` key in [this line](https://github.com/asuc-octo/berkeley-mobile-ios/blob/a6b201ce278935706f32e4ed10d58956ce36d298/berkeley-mobile/Fitness/GymDataSource/GymDataSource.swift#L44) with `" link"`.