### PR TITLE
Firebase Analytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,6 @@ target 'berkeley-mobile' do
   use_frameworks!
 
   # Pods for berkeley-mobile
-  pod 'Firebase/Core'
+  pod 'Firebase/Analytics'
   pod 'Firebase/Firestore'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -218,6 +218,8 @@ PODS:
   - BoringSSL-GRPC/Implementation (0.0.7):
     - BoringSSL-GRPC/Interface (= 0.0.7)
   - BoringSSL-GRPC/Interface (0.0.7)
+  - Firebase/Analytics (6.33.0):
+    - Firebase/Core
   - Firebase/Core (6.33.0):
     - Firebase/CoreOnly
     - FirebaseAnalytics (= 6.8.3)
@@ -321,7 +323,7 @@ PODS:
   - PromisesObjC (1.2.10)
 
 DEPENDENCIES:
-  - Firebase/Core
+  - Firebase/Analytics
   - Firebase/Firestore
 
 SPEC REPOS:
@@ -361,6 +363,6 @@ SPEC CHECKSUMS:
   nanopb: 59317e09cf1f1a0af72f12af412d54edf52603fc
   PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
 
-PODFILE CHECKSUM: 08b990b6a0794354db9956ba6224a0f3aa758485
+PODFILE CHECKSUM: b5192562b962f38d68b0cbdd5952e8929e30481e
 
 COCOAPODS: 1.9.3

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -218,6 +218,8 @@ PODS:
   - BoringSSL-GRPC/Implementation (0.0.7):
     - BoringSSL-GRPC/Interface (= 0.0.7)
   - BoringSSL-GRPC/Interface (0.0.7)
+  - Firebase/Analytics (6.33.0):
+    - Firebase/Core
   - Firebase/Core (6.33.0):
     - Firebase/CoreOnly
     - FirebaseAnalytics (= 6.8.3)
@@ -321,7 +323,7 @@ PODS:
   - PromisesObjC (1.2.10)
 
 DEPENDENCIES:
-  - Firebase/Core
+  - Firebase/Analytics
   - Firebase/Firestore
 
 SPEC REPOS:
@@ -361,6 +363,6 @@ SPEC CHECKSUMS:
   nanopb: 59317e09cf1f1a0af72f12af412d54edf52603fc
   PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
 
-PODFILE CHECKSUM: 08b990b6a0794354db9956ba6224a0f3aa758485
+PODFILE CHECKSUM: b5192562b962f38d68b0cbdd5952e8929e30481e
 
 COCOAPODS: 1.9.3

--- a/berkeley-mobile/Calendar/CalendarViewController.swift
+++ b/berkeley-mobile/Calendar/CalendarViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Firebase
 
 fileprivate let kViewMargin: CGFloat = 16
 
@@ -63,6 +64,15 @@ class CalendarViewController: UIViewController {
         segmentedControl.view.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
         segmentedControl.view.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
         segmentedControl.view.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+    }
+}
+
+// MARK: - Analytics
+
+extension CalendarViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.logEvent("opened_events_screen", parameters: nil)
     }
 }
 

--- a/berkeley-mobile/Dining/DiningDetailViewController.swift
+++ b/berkeley-mobile/Dining/DiningDetailViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import CoreLocation
+import Firebase
 
 fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
 fileprivate let kViewMargin: CGFloat = 16
@@ -168,5 +169,14 @@ extension DiningDetailViewController: UITableViewDelegate, UITableViewDataSource
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return DiningDetailViewController.cellHeight + DiningDetailViewController.cellSpacingHeight
+    }
+}
+
+// MARK: - Analytics
+
+extension DiningDetailViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.logEvent("opened_food", parameters: ["dining_location" : diningHall.name])
     }
 }

--- a/berkeley-mobile/Dining/DiningViewController.swift
+++ b/berkeley-mobile/Dining/DiningViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import MapKit
+import Firebase
 
 class DiningViewController: UIViewController, SearchDrawerViewDelegate {
     
@@ -63,6 +63,8 @@ class DiningViewController: UIViewController, SearchDrawerViewDelegate {
     }
 }
 
+// MARK: TableView Delegate and Data Source
+
 extension DiningViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if let cell = tableView.dequeueReusableCell(withIdentifier: FilterTableViewCell.kCellIdentifier, for: indexPath) as? FilterTableViewCell {
@@ -83,6 +85,8 @@ extension DiningViewController: UITableViewDelegate, UITableViewDataSource {
         tableView.deselectRow(at: indexPath, animated: true)
     }
 }
+
+// MARK: View
 
 extension DiningViewController {
     // General card page
@@ -138,5 +142,13 @@ extension DiningViewController {
         self.filterTableView.tableView.dataSource = self
         self.filterTableView.tableView.delegate = self
     }
-    
+}
+
+// MARK: - Analytics
+
+extension DiningViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.logEvent("opened_food_screen", parameters: nil)
+    }
 }

--- a/berkeley-mobile/Fitness/FitnessViewController.swift
+++ b/berkeley-mobile/Fitness/FitnessViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import MapKit
+import Firebase
 
 fileprivate let kHeaderFont: UIFont = Font.bold(24)
 fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
@@ -297,4 +297,13 @@ extension FitnessViewController {
         self.filterTableView.tableView.delegate = gymsController
     }
     
+}
+
+// MARK: - Analytics
+
+extension FitnessViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.logEvent("opened_gym_screen", parameters: nil)
+    }
 }

--- a/berkeley-mobile/Fitness/GymDetailViewController.swift
+++ b/berkeley-mobile/Fitness/GymDetailViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Firebase
 
 fileprivate let kViewMargin: CGFloat = 16
 
@@ -110,5 +111,14 @@ extension GymDetailViewController {
         scrollingStackView.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
         scrollingStackView.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
         scrollingStackView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
+    }
+}
+
+// MARK: - Analytics
+
+extension GymDetailViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.logEvent("opened_gym", parameters: ["gym" : gym.name])
     }
 }

--- a/berkeley-mobile/Libraries/LibraryDetailViewController.swift
+++ b/berkeley-mobile/Libraries/LibraryDetailViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Firebase
 
 fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
 fileprivate let kViewMargin: CGFloat = 16
@@ -98,5 +99,14 @@ extension LibraryDetailViewController {
         scrollingStackView.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
         scrollingStackView.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
         scrollingStackView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
+    }
+}
+
+// MARK: - Analytics
+
+extension LibraryDetailViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.logEvent("opened_library", parameters: ["library" : library.name])
     }
 }

--- a/berkeley-mobile/Libraries/LibraryViewController.swift
+++ b/berkeley-mobile/Libraries/LibraryViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import MapKit
+import Firebase
 
 fileprivate let kViewMargin: CGFloat = 16
 
@@ -140,5 +140,13 @@ class LibraryViewController: UIViewController, UITableViewDataSource, UITableVie
         }
         return UITableViewCell()
     }
-    
+}
+
+// MARK: - Analytics
+
+extension LibraryViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.logEvent("opened_library_screen", parameters: nil)
+    }
 }

--- a/berkeley-mobile/Map/MapViewController.swift
+++ b/berkeley-mobile/Map/MapViewController.swift
@@ -266,8 +266,8 @@ extension MapViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
         // if map marker is selected, hide the top drawer to show the marker detail
         if let annotation = view.annotation as? MapMarker {
-            // Log the display name of the marker that is selected.
-            Analytics.logEvent("point_of_interest_clicked", parameters: ["Place": annotation.title])
+            // Log the display name of the marker that is selected, `Unknown` if no title exists.
+            Analytics.logEvent("point_of_interest_clicked", parameters: ["Place": annotation.title ?? "Unknown"])
             markerDetail.marker = annotation
             mainContainer?.hideTop()
         }

--- a/berkeley-mobile/Map/MapViewController.swift
+++ b/berkeley-mobile/Map/MapViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import MapKit
+import Firebase
 
 fileprivate let kViewMargin: CGFloat = 16
 
@@ -217,21 +218,24 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
 
 }
 
-// MARK: FilterViewDelegate
+// MARK: FilterViewDelegate, Analytics
 
 extension MapViewController: FilterViewDelegate {
 
     func filterView(_ filterView: FilterView, didSelect index: Int) {
+        if let category = filters[safe: index]?.label {
+            // Log the display name of the marker category that is selected.
+            Analytics.logEvent("map_icon_clicked", parameters: ["Category": category])
+        }
         updateMapMarkers()
     }
     
     func filterView(_ filterView: FilterView, didDeselect index: Int) {
         updateMapMarkers()
     }
-    
 }
 
-// MARK: MKMapViewDelegate {
+// MARK: MKMapViewDelegate, Analytics {
 
 extension MapViewController: MKMapViewDelegate {
     
@@ -262,6 +266,8 @@ extension MapViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
         // if map marker is selected, hide the top drawer to show the marker detail
         if let annotation = view.annotation as? MapMarker {
+            // Log the display name of the marker that is selected.
+            Analytics.logEvent("point_of_interest_clicked", parameters: ["Place": annotation.title])
             markerDetail.marker = annotation
             mainContainer?.hideTop()
         }
@@ -282,7 +288,6 @@ extension MapViewController: MKMapViewDelegate {
     }
     
     func mapView(_ mapView: MKMapView, regionWillChangeAnimated animated: Bool) {
-        
         guard userLocationButton != nil else {return}
         guard locationButtonTapped != nil else {return}
         if !locationButtonTapped {

--- a/berkeley-mobile/Resources/ResourceDetailViewController.swift
+++ b/berkeley-mobile/Resources/ResourceDetailViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Firebase
 
 fileprivate let kViewMargin: CGFloat = 16
 
@@ -98,5 +99,14 @@ extension ResourceDetailViewController {
         scrollingStackView.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
         scrollingStackView.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
         scrollingStackView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
+    }
+}
+
+// MARK: - Analytics
+
+extension ResourceDetailViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.logEvent("opened_resource", parameters: ["resource" : resource.name])
     }
 }

--- a/berkeley-mobile/Resources/ResourcesViewController.swift
+++ b/berkeley-mobile/Resources/ResourcesViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Firebase
 
 fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
 fileprivate let kViewMargin: CGFloat = 16
@@ -120,5 +121,13 @@ extension ResourcesViewController {
 
         resourcesCard = card
     }
-    
+}
+
+// MARK: - Analytics
+
+extension ResourcesViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.logEvent("opened_resource_screen", parameters: nil)
+    }
 }


### PR DESCRIPTION
Added Firebase Analytics. List of current events logged, will add more in future PRs:

### Libraries
- `opened_library_screen`: The Libraries tab is opened.
- `opened_library`: A library is selected.
  - Sends `library`: Display name of the selected library.

### Dining
- `opened_food_screen`: The Dining tab is opened.
- `opened_food`: A dining location is selected.
  - Sends `dining_location`: Display name of the selected dining location

### Fitness
- `opened_gym_screen`: The Fitness tab is opened.
- `opened_gym`: A fitness location is selected.
  - Sends `gym`: Display name of the selected fitness center.

### Resources
- `opened_resource_screen`: The Resources tab is opened.
- `opened_resource`: A resource is selected.
  - Sends `resource`: Display name of the selected resource.

### Calendar
- `opened_events_screen`: The Calendar tab is opened.

### Map
- `map_icon_clicked`: A map marker category (Microwaves, Cafes, etc.) is selected.
  - Sends `Category`: Display name of the selected category (e.g. `"Mental Health"`).
- `point_of_interest_clicked`: A map annotation (a single location) is selected.
  - Sends `Place`: Display name of the selected location (e.g. `"Terrace Cafe Microwave"`).

### Search
- _None_

#

@sidthesquid thoughts on logging the Library / Dining Hall / Gym / etc. names for `opened_library`, `opened_food`, `opened_gym`, `opened_resource`? The [Android PR](https://github.com/asuc-octo/berkeley-mobile-android-persona/pull/89) doesn't do this, which is why I'm asking.
