### PR TITLE
Prevent Empty Descriptions

### DIFF
--- a/berkeley-mobile/Common/DetailView/DescriptionCardView.swift
+++ b/berkeley-mobile/Common/DetailView/DescriptionCardView.swift
@@ -21,7 +21,8 @@ class DescriptionCardView: CardView {
     private var descriptionLabel: UILabel!
 
     public init?(description: String?) {
-        guard let description = description else { return nil }
+        guard let description = description?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !description.isEmpty else { return nil }
         super.init(frame: .zero)
 
         // Default padding for the card


### PR DESCRIPTION
Fixes an issue noticed when reviewing #224: in cases where `description` is `""` instead of `nil`, an empty card would still be displayed:
<img width="584" alt="Screen Shot 2020-10-24 at 11 50 43 PM" src="https://user-images.githubusercontent.com/41145903/97101190-7b824480-1658-11eb-8c45-53e7ee20006d.png">

Prevents this by trimming `description` of whitespace and failing the initializer of `DescriptionCardView` if the description is an empty string.