### PR TITLE
Add events to calendar (fitness classes, academic & career events)

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		299ACFB4244A5F90000F3E86 /* HasOccupancy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299ACFB3244A5F90000F3E86 /* HasOccupancy.swift */; };
 		29AB5BBF241D8766007C3ECA /* HasOpenTimes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AB5BBE241D8766007C3ECA /* HasOpenTimes.swift */; };
 		29AB5BC5241D8CB4007C3ECA /* FilterTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AB5BC4241D8CB4007C3ECA /* FilterTableView.swift */; };
+		29B1D307254E1C8700BAD88F /* EventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B1D306254E1C8700BAD88F /* EventManager.swift */; };
 		29B3A1742439A60A00093750 /* DiningMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B3A1732439A60A00093750 /* DiningMenuCell.swift */; };
 		29B3D7862453984A006762E5 /* DrawerViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B3D7852453984A006762E5 /* DrawerViewDelegate.swift */; };
 		29B3D78824539FF3006762E5 /* MainDrawerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B3D78724539FF3006762E5 /* MainDrawerViewController.swift */; };
@@ -254,6 +255,7 @@
 		299ACFB3244A5F90000F3E86 /* HasOccupancy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasOccupancy.swift; sourceTree = "<group>"; };
 		29AB5BBE241D8766007C3ECA /* HasOpenTimes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasOpenTimes.swift; sourceTree = "<group>"; };
 		29AB5BC4241D8CB4007C3ECA /* FilterTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTableView.swift; sourceTree = "<group>"; };
+		29B1D306254E1C8700BAD88F /* EventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventManager.swift; sourceTree = "<group>"; };
 		29B3A1732439A60A00093750 /* DiningMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningMenuCell.swift; sourceTree = "<group>"; };
 		29B3D7852453984A006762E5 /* DrawerViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerViewDelegate.swift; sourceTree = "<group>"; };
 		29B3D78724539FF3006762E5 /* MainDrawerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDrawerViewController.swift; sourceTree = "<group>"; };
@@ -540,6 +542,7 @@
 				13EA64CF2399D50C00FD8E13 /* DataManager.swift */,
 				13B39A8C23E689BC0039FBA2 /* DataSource.swift */,
 				01FA50F024E8B33100DCC490 /* LocationManager.swift */,
+				29B1D306254E1C8700BAD88F /* EventManager.swift */,
 				29EE163E241C4E310041482E /* SortingFunctions.swift */,
 			);
 			path = Data;
@@ -1025,6 +1028,7 @@
 				296F1B272439341300924C8D /* DiningDetailViewController.swift in Sources */,
 				13492D2D240E179F00AD3D1F /* MapMarkerDetailView.swift in Sources */,
 				1346B9192420AD4800383399 /* WeeklyHours.swift in Sources */,
+				29B1D307254E1C8700BAD88F /* EventManager.swift in Sources */,
 				29387E9D24BBBE8E00070BCE /* OccupancyGraphCardView.swift in Sources */,
 				13EA64D02399D50C00FD8E13 /* DataManager.swift in Sources */,
 				29B3A1742439A60A00093750 /* DiningMenuCell.swift in Sources */,

--- a/berkeley-mobile/Calendar/Academic/AcademicCalendarViewController.swift
+++ b/berkeley-mobile/Calendar/Academic/AcademicCalendarViewController.swift
@@ -84,6 +84,9 @@ extension AcademicCalendarViewController: UITableViewDelegate, UITableViewDataSo
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if let event = calendarEntries[safe: indexPath.row] {
+            event.addToDeviceCalendar(vc: self)
+        }
         tableView.deselectRow(at: indexPath, animated: true)
     }
 }
@@ -181,7 +184,6 @@ extension AcademicCalendarViewController {
         let tableView = UITableView()
         tableView.register(EventTableViewCell.self, forCellReuseIdentifier: EventTableViewCell.kCellIdentifier)
         tableView.rowHeight = EventTableViewCell.kCellHeight
-        tableView.allowsSelection = false
         tableView.delegate = self
         tableView.dataSource = self
         tableView.showsVerticalScrollIndicator = false

--- a/berkeley-mobile/Calendar/Campus/CampusEventDetailViewController.swift
+++ b/berkeley-mobile/Calendar/Campus/CampusEventDetailViewController.swift
@@ -23,8 +23,7 @@ class CampusEventDetailViewController: UIViewController {
         setUpScrollView()
         setUpOverviewCard()
         setupDescriptionCard()
-        setUpLearnMoreButton()
-        setUpRegisterButton()
+        setUpButtons()
     }
     
     func setUpBackgroundView() {
@@ -56,27 +55,29 @@ class CampusEventDetailViewController: UIViewController {
         
         scrollingStackView.stackView.addArrangedSubview(descriptionCard)
     }
-
-    func setUpLearnMoreButton() {
-        guard event.sourceLink != nil else { return }
-        
-        scrollingStackView.stackView.addArrangedSubview(learnMoreButton)
+    
+    func setUpButtons() {
+        if event.sourceLink != nil {
+            scrollingStackView.stackView.addArrangedSubview(learnMoreButton)
+        }
+        if event.registerLink != nil {
+            scrollingStackView.stackView.addArrangedSubview(registerButton)
+        }
+        scrollingStackView.stackView.addArrangedSubview(addToCalendarButton)
     }
+    
     @objc private func learnMoreTapped(sender: UIButton) {
         guard let url = event.sourceLink else { return }
         
         presentAlertLinkUrl(title: "Are you sure you want to open Safari?", message: "Berkeley Mobile wants to open a web page with more info for this event.", options: "Cancel", "Yes", website_url: url)
     }
-    
-    func setUpRegisterButton() {
-        guard event.registerLink != nil else { return }
-        
-        scrollingStackView.stackView.addArrangedSubview(registerButton)
-    }
     @objc private func registerTapped(sender: UIButton) {
         guard let url = event.registerLink else { return }
         
         presentAlertLinkUrl(title: "Are you sure you want to open Safari?", message: "Berkeley Mobile wants to open the web page to register for this event.", options: "Cancel", "Yes", website_url: url)
+    }
+    @objc private func addToCalendar(sender: UIButton) {
+        event.addToDeviceCalendar(vc: self)
     }
     
     var learnMoreButton: ActionButton = {
@@ -88,6 +89,12 @@ class CampusEventDetailViewController: UIViewController {
     var registerButton: ActionButton = {
         let button = ActionButton(title: "Register")
         button.addTarget(self, action: #selector(registerTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    var addToCalendarButton: ActionButton = {
+        let button = ActionButton(title: "Add To Calendar")
+        button.addTarget(self, action: #selector(addToCalendar), for: .touchUpInside)
         return button
     }()
     

--- a/berkeley-mobile/Calendar/EventDataSource/EventCalendarEntry.swift
+++ b/berkeley-mobile/Calendar/EventDataSource/EventCalendarEntry.swift
@@ -17,6 +17,19 @@ class EventCalendarEntry: CalendarEvent, HasImage, CanFavorite {
     var description: String?
     var location: String?
     
+    var additionalDescription: String {
+        get {
+            var desc = ""
+            if let registerLink = self.registerLink {
+                desc += "Register: " + registerLink.absoluteString + "\n"
+            }
+            if let sourceLink = self.sourceLink {
+                desc += "Additional Info: " + sourceLink.absoluteString + "\n"
+            }
+            return desc
+        }
+    }
+    
     // MARK: CanFavorite
     var isFavorited: Bool = false
     

--- a/berkeley-mobile/Data/EventManager.swift
+++ b/berkeley-mobile/Data/EventManager.swift
@@ -13,7 +13,7 @@ class EventManager: NSObject {
     static let shared = EventManager()
     private let eventStore = EKEventStore()
     
-    public func addEventToCalendar(calendarEvent: CalendarEvent) {
+    public func addEventToCalendar(calendarEvent: CalendarEvent, completion: @escaping (Bool) -> Void) {
         eventStore.requestAccess(to: .event) { (granted, error) in
             if granted && error == nil {
                 let event: EKEvent = EKEvent(eventStore: self.eventStore)
@@ -25,11 +25,14 @@ class EventManager: NSObject {
                 event.calendar = self.eventStore.defaultCalendarForNewEvents
                 do {
                     try self.eventStore.save(event, span: .thisEvent)
+                    completion(true)
                 } catch let error as NSError {
                     print("failed to save event with error : \(error)")
+                    completion(false)
                 }
             } else {
                 print("failed to save event with error : \(String(describing: error)) or access not granted")
+                completion(false)
             }
         }
     }

--- a/berkeley-mobile/Data/EventManager.swift
+++ b/berkeley-mobile/Data/EventManager.swift
@@ -1,0 +1,36 @@
+//
+//  EventManager.swift
+//  berkeley-mobile
+//
+//  Created by Shawn Huang on 10/31/20.
+//  Copyright © 2020 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+import EventKit
+
+class EventManager: NSObject {
+    static let shared = EventManager()
+    private let eventStore = EKEventStore()
+    
+    public func addEventToCalendar(calendarEvent: CalendarEvent) {
+        eventStore.requestAccess(to: .event) { (granted, error) in
+            if (granted) && (error == nil) {
+                let event: EKEvent = EKEvent(eventStore: self.eventStore)
+                event.title = calendarEvent.name
+                event.startDate = calendarEvent.date
+                event.endDate = calendarEvent.end ?? calendarEvent.date
+                event.location = calendarEvent.location
+                event.notes = calendarEvent.additionalDescription + (calendarEvent.description ?? "")
+                event.calendar = self.eventStore.defaultCalendarForNewEvents
+                do {
+                    try self.eventStore.save(event, span: .thisEvent)
+                } catch let error as NSError {
+                    print("failed to save event with error : \(error)")
+                }
+            } else {
+                print("failed to save event with error : \(String(describing: error)) or access not granted")
+            }
+        }
+    }
+}

--- a/berkeley-mobile/Data/EventManager.swift
+++ b/berkeley-mobile/Data/EventManager.swift
@@ -15,7 +15,7 @@ class EventManager: NSObject {
     
     public func addEventToCalendar(calendarEvent: CalendarEvent) {
         eventStore.requestAccess(to: .event) { (granted, error) in
-            if (granted) && (error == nil) {
+            if granted && error == nil {
                 let event: EKEvent = EKEvent(eventStore: self.eventStore)
                 event.title = calendarEvent.name
                 event.startDate = calendarEvent.date

--- a/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
+++ b/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
@@ -47,9 +47,9 @@ extension CalendarEvent {
             EventManager.shared.addEventToCalendar(calendarEvent: self) { success in
                 DispatchQueue.main.async {
                     if success {
-                        vc.presentSuccessAlert(title: "Successfully added to Calendar")
+                        vc.presentSuccessAlert(title: "Successfully added to calendar")
                     } else {
-                        vc.presentFailureAlert(title: "Failed to Add to Calendar", message: "Make sure Berkeley Mobile has access to your Calendar and try again.")
+                        vc.presentFailureAlert(title: "Failed to add to calendar", message: "Make sure Berkeley Mobile has access to your calendar and try again.")
                     }
                 }
             }

--- a/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
+++ b/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
@@ -11,25 +11,25 @@ import UIKit
 
 /// Items conforming to this protocol are events that can be represented on a calendar.
 protocol CalendarEvent {
-
+    
     /// The name of the event.
     var name: String { get set }
-
+    
     /// The date and time that the event starts.
     var date: Date { get set }
     
     /// Formatted date string to display. Shows "Date / Time" or "Today / Time".
     var dateString: String { get }
-
+    
     /// The end date for the event. This value can be `nil` (e.g. for a deadline or reminder).
     var end: Date? { get set }
-
+    
     /// An optional description for the event.
     var description: String? { get set }
     
     /// Subclass specific additional description to include when adding the event to the user's calendar. Should be used to include details like gym class trainer, links, etc.
     var additionalDescription: String { get }
-
+    
     /// A string describing where the event will be held.
     ///
     /// When the value of this variable is a URL, this is an online event.
@@ -44,7 +44,15 @@ extension CalendarEvent {
         let alertController = UIAlertController(title: "Add to Calendar", message: "Would you like to add this event to your calendar?", preferredStyle: .alert)
         alertController.addAction(UIAlertAction.init(title: "Cancel", style: .cancel))
         alertController.addAction(UIAlertAction.init(title: "Yes", style: .default, handler: { _ in
-            EventManager.shared.addEventToCalendar(calendarEvent: self)
+            EventManager.shared.addEventToCalendar(calendarEvent: self) { success in
+                DispatchQueue.main.async {
+                    if success {
+                        vc.presentSuccessAlert(title: "Successfully added to Calendar")
+                    } else {
+                        vc.presentFailureAlert(title: "Failed to Add to Calendar", message: "Make sure Berkeley Mobile has access to your Calendar and try again.")
+                    }
+                }
+            }
         }))
         vc.present(alertController, animated: true, completion: nil)
     }

--- a/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
+++ b/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
@@ -31,8 +31,6 @@ protocol CalendarEvent {
     var additionalDescription: String { get }
     
     /// A string describing where the event will be held.
-    ///
-    /// When the value of this variable is a URL, this is an online event.
     var location: String? { get set }
 }
 

--- a/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
+++ b/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Items conforming to this protocol are events that can be represented on a calendar.
 protocol CalendarEvent {
@@ -25,6 +26,9 @@ protocol CalendarEvent {
 
     /// An optional description for the event.
     var description: String? { get set }
+    
+    /// Subclass specific additional description to include when adding the event to the user's calendar. Should be used to include details like gym class trainer, links, etc.
+    var additionalDescription: String { get }
 
     /// A string describing where the event will be held.
     ///
@@ -36,8 +40,13 @@ extension CalendarEvent {
     /// Prompts and adds this event to the user's local calendar.
     ///
     /// Override this function if additional fields need to be included in the exported event.
-    public func addToDeviceCalendar() {
-        // TODO: https://www.notion.so/Sprint-Board-iOS-3a44a1f5f7044adab2ea4b7827e7ea5c?p=a47d9fb0b7174b919afde6f52df0f3c7
+    public func addToDeviceCalendar(vc: UIViewController) {
+        let alertController = UIAlertController(title: "Add to Calendar", message: "Would you like to add this event to your calendar?", preferredStyle: .alert)
+        alertController.addAction(UIAlertAction.init(title: "Cancel", style: .cancel))
+        alertController.addAction(UIAlertAction.init(title: "Yes", style: .default, handler: { _ in
+            EventManager.shared.addEventToCalendar(calendarEvent: self)
+        }))
+        vc.present(alertController, animated: true, completion: nil)
     }
     
     var dateString: String {

--- a/berkeley-mobile/Fitness/Fitness+Controllers/GymClassesController.swift
+++ b/berkeley-mobile/Fitness/Fitness+Controllers/GymClassesController.swift
@@ -18,49 +18,24 @@ class GymClassesController: NSObject {
     weak var vc: FitnessViewController!
 }
 
-// MARK: - "Upcoming" UICollectionView
-
-// Dummy Data
-extension GymClassesController: UICollectionViewDataSource {
-    
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return vc.upcomingClasses.count
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CardCollectionView.kCellIdentifier, for: indexPath)
-        if let card = cell as? CardCollectionViewCell {
-            if let gymClass = vc.upcomingClasses[safe: indexPath.row] {
-                card.title.text = gymClass.name
-                card.subtitle.text = gymClass.description(components: [.date, .startTime])
-                card.badge.text = gymClass.type
-                card.badge.backgroundColor = gymClass.color
-                card.badge.isHidden = gymClass.type == nil
-            }
-        }
-        return cell
-    }
-    
-}
-
-// MARK: - "Today" UITableView
+// MARK: - "Classes" UITableView
 
 extension GymClassesController: UITableViewDataSource {
     
     static let kCellIdentifier = "GymClassTableCell"
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return vc.todayClasses.count
+        return vc.futureClasses.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: GymClassesController.kCellIdentifier, for: indexPath)
         if let cell = cell as? EventTableViewCell {
-            if let gymClass = vc.todayClasses[safe: indexPath.row] {
+            if let gymClass = vc.futureClasses[safe: indexPath.row] {
                 cell.cellConfigure(event: gymClass, type: gymClass.type, color: gymClass.color)
-                cell.eventTime.text = gymClass.description(components: [.startTime, .duration, .location])
+                cell.eventTime.text = gymClass.description(components: [.date, .startTime, .duration, .location])
                 
-                if let url = gymClass.website_link, gymClass.location == "Zoom" {
+                if let url = gymClass.link, gymClass.location == "Zoom" {
                     let tapGesture = DetailTapGestureRecognizer(target: self, action:
                                                                 #selector(GymClassesController.zoomTapped(gesture:)))
                     tapGesture.eventUrl = URL(string: url)

--- a/berkeley-mobile/Fitness/Fitness+Controllers/GymClassesController.swift
+++ b/berkeley-mobile/Fitness/Fitness+Controllers/GymClassesController.swift
@@ -55,3 +55,10 @@ extension GymClassesController: UITableViewDataSource {
     }
     
 }
+
+extension GymClassesController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        vc.futureClasses[indexPath.row].addToDeviceCalendar(vc: vc)
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}

--- a/berkeley-mobile/Fitness/FitnessViewController.swift
+++ b/berkeley-mobile/Fitness/FitnessViewController.swift
@@ -182,7 +182,7 @@ extension FitnessViewController {
         classesTable.showsVerticalScrollIndicator = false
         classesTable.rowHeight = EventTableViewCell.kCellHeight
         classesTable.dataSource = classesController
-        classesTable.delegate = self
+        classesTable.delegate = classesController
         classesTable.register(EventTableViewCell.self, forCellReuseIdentifier: GymClassesController.kCellIdentifier)
         card.addSubview(classesTable)
         classesTable.translatesAutoresizingMaskIntoConstraints = false
@@ -240,13 +240,6 @@ extension FitnessViewController {
         self.filterTableView.tableView.delegate = gymsController
     }
     
-}
-
-extension FitnessViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        futureClasses[indexPath.row].addToDeviceCalendar(vc: self)
-        tableView.deselectRow(at: indexPath, animated: false)
-    }
 }
 
 // MARK: - Analytics

--- a/berkeley-mobile/Fitness/FitnessViewController.swift
+++ b/berkeley-mobile/Fitness/FitnessViewController.swift
@@ -12,9 +12,8 @@ import Firebase
 fileprivate let kHeaderFont: UIFont = Font.bold(24)
 fileprivate let kCardPadding: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
 fileprivate let kViewMargin: CGFloat = 16
-fileprivate let kTodayClassesHeight: CGFloat = 300
-fileprivate let kTodayClassesCollapsedHeight: CGFloat = 92
-fileprivate let kUpcomingCollapsedHeight: CGFloat = 16  // Same as TableView 0 elements
+fileprivate let kClassesHeight: CGFloat = 300
+fileprivate let kClassesCollapsedHeight: CGFloat = 92
 
 class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
 
@@ -32,26 +31,21 @@ class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
     private var scrollView: UIScrollView!
     private var content: UIView!
     
-    private var upcomingCard: CardView!
-    private var todayCard: CardView!
+    private var classesCard: CardView!
     private var gymCard: CardView!
     
     private var showButton: UIButton!
     private var missingClassesView: MissingDataView!
-    private var missingUpcomingView: MissingDataView!
     
     private var bClassesExpanded = false
     
-    // For use in the "Today" card
+    // For use in the "Classes" card
     private var classesTable: UITableView!
-    // For use in the "Upcoming" card
-    private var classesCollection: CardCollectionView!
     // To display a list of gyms in the "Fitness Centers" card
     var filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
     
     var gyms: [Gym] = []
-    var upcomingClasses: [GymClass] = []
-    var todayClasses: [GymClass] = []
+    var futureClasses: [GymClass] = []
     
     private var classesController = GymClassesController()
     private var gymsController = GymsController()
@@ -63,8 +57,7 @@ class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
         view.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         
         setupScrollView()
-        setupUpcomingClasses()
-        setupTodayClasses()
+        setupClasses()
         setupGyms()
         
         // Update `filterTableView` when user location is updated.
@@ -86,27 +79,17 @@ class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
                 lhs.date == rhs.date ? lhs.name < rhs.name :  lhs.date < rhs.date
             }
             
-            self.todayClasses = classes.filter { (classes) -> Bool in
-                guard let start = classes.first?.date else { return false }
-                return Calendar.current.isDateInToday(start)
-            }.first?.sorted(by: sortFn) ?? []
-            self.upcomingClasses = classes.reduce([], +).sorted(by: sortFn)
+            self.futureClasses = classes.reduce([], +).sorted(by: sortFn)
             
-            if (self.upcomingClasses.count == 0) {
-                self.missingUpcomingView.isHidden = false
-                self.classesCollection.setHeightConstraint(kUpcomingCollapsedHeight)
-            }
-            
-            if (self.todayClasses.count == 0) {
+            if (self.futureClasses.count == 0) {
                 self.showButton.isHidden = true
                 self.missingClassesView.isHidden = false
-                self.todayCard.setHeightConstraint(kTodayClassesCollapsedHeight)
+                self.classesCard.setHeightConstraint(kClassesCollapsedHeight)
             }
             
             self.scrollView.layoutSubviews()
             
             self.classesTable.reloadData()
-            self.classesCollection.reloadData()
         }
         
         // fetch gyms and fetch occupancy data afterwards
@@ -125,13 +108,13 @@ class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
     @objc func willExpandClasses() {
         UIView.animate(withDuration: 0.2) {
             if !self.bClassesExpanded {
-                self.todayCard.heightConstraint?.constant = self.view.frame.height
-                self.todayCard.heightConstraint?.constant -=  self.view.layoutMargins.top + self.view.layoutMargins.bottom
+                self.classesCard.heightConstraint?.constant = self.view.frame.height
+                self.classesCard.heightConstraint?.constant -=  self.view.layoutMargins.top + self.view.layoutMargins.bottom
             } else {
-                self.todayCard.heightConstraint?.constant = kTodayClassesHeight
+                self.classesCard.heightConstraint?.constant = kClassesHeight
             }
             self.bClassesExpanded = !self.bClassesExpanded
-            self.scrollView.contentOffset = CGPoint(x: 0, y: self.todayCard.frame.minY)
+            self.scrollView.contentOffset = CGPoint(x: 0, y: self.classesCard.frame.minY)
             self.scrollView.contentOffset.y -= self.view.layoutMargins.top
             self.view.layoutIfNeeded()
             self.viewDidLayoutSubviews()
@@ -163,7 +146,7 @@ extension FitnessViewController {
     }
     
     // Upcoming Classes
-    func setupUpcomingClasses() {
+    func setupClasses() {
         let card = CardView()
         card.layoutMargins = kCardPadding
         scrollView.addSubview(card)
@@ -171,53 +154,11 @@ extension FitnessViewController {
         card.topAnchor.constraint(equalTo: content.layoutMarginsGuide.topAnchor).isActive = true
         card.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
         card.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
-        
-        let contentView = UIView()
-        contentView.layer.masksToBounds = true
-        card.addSubview(contentView)
-        contentView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.setConstraintsToView(top: card, bottom: card, left: card, right: card)
+        card.heightAnchor.constraint(equalToConstant: kClassesHeight).isActive = true
         
         let headerLabel = UILabel()
         headerLabel.font = kHeaderFont
-        headerLabel.text = "Upcoming"
-        contentView.addSubview(headerLabel)
-        headerLabel.translatesAutoresizingMaskIntoConstraints = false
-        headerLabel.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor).isActive = true
-        headerLabel.leftAnchor.constraint(equalTo: card.layoutMarginsGuide.leftAnchor).isActive = true
-        headerLabel.rightAnchor.constraint(equalTo: card.layoutMarginsGuide.rightAnchor).isActive = true
-        
-        let collectionView = CardCollectionView(frame: .zero)
-        collectionView.dataSource = classesController
-        collectionView.contentInset = UIEdgeInsets(top: 0, left: card.layoutMargins.left, bottom: 0, right: card.layoutMargins.right)
-        contentView.addSubview(collectionView)
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.topAnchor.constraint(equalTo: headerLabel.bottomAnchor, constant: kViewMargin).isActive = true
-        collectionView.heightAnchor.constraint(equalToConstant: CardCollectionViewCell.kCardSize.height).isActive = true
-        collectionView.leftAnchor.constraint(equalTo: card.leftAnchor).isActive = true
-        collectionView.rightAnchor.constraint(equalTo: card.rightAnchor).isActive = true
-        
-        collectionView.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor).isActive = true
-        upcomingCard = card
-        classesCollection = collectionView
-        
-        missingUpcomingView = MissingDataView(parentView: collectionView, text: "No upcoming classes")
-    }
-    
-    // Upcoming Classes
-    func setupTodayClasses() {
-        let card = CardView()
-        card.layoutMargins = kCardPadding
-        scrollView.addSubview(card)
-        card.translatesAutoresizingMaskIntoConstraints = false
-        card.topAnchor.constraint(equalTo: upcomingCard.bottomAnchor, constant: kViewMargin).isActive = true
-        card.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
-        card.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
-        card.heightAnchor.constraint(equalToConstant: kTodayClassesHeight).isActive = true
-        
-        let headerLabel = UILabel()
-        headerLabel.font = kHeaderFont
-        headerLabel.text = "Today"
+        headerLabel.text = "Classes"
         card.addSubview(headerLabel)
         headerLabel.translatesAutoresizingMaskIntoConstraints = false
         headerLabel.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor).isActive = true
@@ -237,11 +178,11 @@ extension FitnessViewController {
         scheduleButton.leftAnchor.constraint(greaterThanOrEqualTo: headerLabel.rightAnchor, constant: 5).isActive = true
         
         classesTable = UITableView()
-        classesTable.allowsSelection = false
         classesTable.separatorStyle = .none
         classesTable.showsVerticalScrollIndicator = false
         classesTable.rowHeight = EventTableViewCell.kCellHeight
         classesTable.dataSource = classesController
+        classesTable.delegate = self
         classesTable.register(EventTableViewCell.self, forCellReuseIdentifier: GymClassesController.kCellIdentifier)
         card.addSubview(classesTable)
         classesTable.translatesAutoresizingMaskIntoConstraints = false
@@ -250,7 +191,7 @@ extension FitnessViewController {
         classesTable.rightAnchor.constraint(equalTo: card.layoutMarginsGuide.rightAnchor).isActive = true
         classesTable.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor).isActive = true
                 
-        todayCard = card
+        classesCard = card
         showButton = scheduleButton
         missingClassesView = MissingDataView(parentView: classesTable, text: "No classes found")
     }
@@ -261,7 +202,7 @@ extension FitnessViewController {
         card.layoutMargins = kCardPadding
         scrollView.addSubview(card)
         card.translatesAutoresizingMaskIntoConstraints = false
-        card.topAnchor.constraint(equalTo: todayCard.bottomAnchor, constant: kViewMargin).isActive = true
+        card.topAnchor.constraint(equalTo: classesCard.bottomAnchor, constant: kViewMargin).isActive = true
         card.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
         card.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
         card.heightAnchor.constraint(equalTo: view.layoutMarginsGuide.heightAnchor).isActive = true
@@ -299,6 +240,13 @@ extension FitnessViewController {
         self.filterTableView.tableView.delegate = gymsController
     }
     
+}
+
+extension FitnessViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        futureClasses[indexPath.row].addToDeviceCalendar(vc: self)
+        tableView.deselectRow(at: indexPath, animated: false)
+    }
 }
 
 // MARK: - Analytics

--- a/berkeley-mobile/Fitness/GymClassDataSource/GymClass.swift
+++ b/berkeley-mobile/Fitness/GymClassDataSource/GymClass.swift
@@ -18,9 +18,23 @@ class GymClass: CalendarEvent {
     var end: Date?
     var description: String?
     var location: String?
-    var website_link: String?
+    
+    var additionalDescription: String {
+        get {
+            var desc = ""
+            if let link = self.link {
+                desc += "Link: " + link + "\n"
+            }
+            if let trainer = self.trainer {
+                desc += "Trainer: " + trainer + "\n"
+            }
+            return desc
+        }
+    }
 
     // MARK: Additional Fields
+    /// Link to zoom or website.
+    var link: String?
 
     /// The trainer leading this gym class.
     var trainer: String?
@@ -33,13 +47,13 @@ class GymClass: CalendarEvent {
         return GymClassType(rawValue: type ?? "")?.color ?? Color.eventDefault
     }
 
-    init(name: String, start_time: Date, end_time: Date, class_type: String?, location: String?, website_link: String?, trainer: String?) {
+    init(name: String, start_time: Date, end_time: Date, class_type: String?, location: String?, link: String?, trainer: String?) {
         self.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
         self.date = start_time
         self.end = end_time
         self.type = class_type
         self.location = location
-        self.website_link = website_link?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.link = link?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.trainer = trainer?.trimmingCharacters(in: .whitespacesAndNewlines)
     }
     

--- a/berkeley-mobile/Fitness/GymClassDataSource/GymClassDataSource.swift
+++ b/berkeley-mobile/Fitness/GymClassDataSource/GymClassDataSource.swift
@@ -52,7 +52,7 @@ class GymClassDataSource: DataSource {
                                 end_time: Date(timeIntervalSince1970: end_time),
                                 class_type: dict["class type"] as? String,
                                 location: dict["location"] as? String,
-                                website_link: dict["link"] as? String,
+                                link: dict["link"] as? String,
                                 trainer: dict["trainer"] as? String)
         return gymClass
     }

--- a/berkeley-mobile/Info.plist
+++ b/berkeley-mobile/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Calendar access will be used to allow you to add events you select to your calendar.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -26,7 +28,7 @@
 		<true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>We need your location to provide location based points of interest and transit directions.</string>
+	<string>Your location will be used to calculate distance to points of interest, display your location on the map, and for other location-based features.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Apercu Regular.otf</string>

--- a/berkeley-mobile/Utils/UIViewController+Extensions.swift
+++ b/berkeley-mobile/Utils/UIViewController+Extensions.swift
@@ -77,7 +77,7 @@ extension UIViewController {
     public func presentSuccessAlert(title: String) {
         let alert = UIAlertController(title: title, message: "", preferredStyle: .alert)
         self.present(alert, animated: true, completion: nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
             alert.dismiss(animated: true, completion: nil)
         }
     }

--- a/berkeley-mobile/Utils/UIViewController+Extensions.swift
+++ b/berkeley-mobile/Utils/UIViewController+Extensions.swift
@@ -73,4 +73,18 @@ extension UIViewController {
         }
         self.present(alertController, animated: true, completion: nil)
     }
+    
+    public func presentSuccessAlert(title: String) {
+        let alert = UIAlertController(title: title, message: "", preferredStyle: .alert)
+        self.present(alert, animated: true, completion: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            alert.dismiss(animated: true, completion: nil)
+        }
+    }
+    
+    public func presentFailureAlert(title: String, message: String) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction.init(title: "Ok", style: .cancel))
+        self.present(alertController, animated: true, completion: nil)
+    }
 }


### PR DESCRIPTION
Allows users to tap fitness class cells, academic cells, or buttons in career event details to add an event to their Apple calendar.

- EventManager: class to manage all interaction with user's calendar, set parameters for added event
- CalendarEvent
  - additionalDescription: allows different classes to include different elements in the notes/description section of the event. this appears in addition to the "description" string. (e.g. trainer, register link)
  - addToDeviceCalendar: prompts the user with an alert if they want to add the event to their calendar

Also removed fitness class upcoming card and changed the "Today" card to show all future classes.
Added message to display when requesting calendar permission, modified location access message to better reflect what location is used for.

Screenshots:
![IMG_1836](https://user-images.githubusercontent.com/20230668/98453888-0bbd9080-2113-11eb-9671-de772e6c2d3f.PNG)
![IMG_1838](https://user-images.githubusercontent.com/20230668/98453893-11b37180-2113-11eb-8f45-721cab44b4c4.PNG)
![IMG_1839](https://user-images.githubusercontent.com/20230668/98453895-16782580-2113-11eb-9a6e-f5aa7990a34b.jpg)
![IMG_1840](https://user-images.githubusercontent.com/20230668/98453896-1841e900-2113-11eb-83c8-aac797c17023.PNG)

