### PR TITLE
Campus Resource Tags

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		01B2502F2516C45800CBA459 /* EventCalendarEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B2502E2516C45800CBA459 /* EventCalendarEntry.swift */; };
 		01BC8EB024E8C3E3005B4969 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BC8EAF24E8C3E3005B4969 /* DetailView.swift */; };
 		01C75E2E25292E5B00C25A32 /* DescriptionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C75E2D25292E5B00C25A32 /* DescriptionCardView.swift */; };
+		01CDFF67257C5F2300D9FBD6 /* ResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDFF66257C5F2300D9FBD6 /* ResourceType.swift */; };
+		01CDFF6A257C614900D9FBD6 /* Colors+Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDFF69257C614900D9FBD6 /* Colors+Resource.swift */; };
 		01D11B8E2504453B00BDF660 /* ScrollingStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B8D2504453B00BDF660 /* ScrollingStackView.swift */; };
 		01D11B902504560700BDF660 /* GymDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B8F2504560700BDF660 /* GymDetailViewController.swift */; };
 		01D11B9225045FC900BDF660 /* CampusResourceDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B9125045FC900BDF660 /* CampusResourceDetailViewController.swift */; };
@@ -167,6 +169,8 @@
 		01B2502E2516C45800CBA459 /* EventCalendarEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventCalendarEntry.swift; sourceTree = "<group>"; };
 		01BC8EAF24E8C3E3005B4969 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		01C75E2D25292E5B00C25A32 /* DescriptionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionCardView.swift; sourceTree = "<group>"; };
+		01CDFF66257C5F2300D9FBD6 /* ResourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceType.swift; sourceTree = "<group>"; };
+		01CDFF69257C614900D9FBD6 /* Colors+Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+Resource.swift"; sourceTree = "<group>"; };
 		01D11B8D2504453B00BDF660 /* ScrollingStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingStackView.swift; sourceTree = "<group>"; };
 		01D11B8F2504560700BDF660 /* GymDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymDetailViewController.swift; sourceTree = "<group>"; };
 		01D11B9125045FC900BDF660 /* CampusResourceDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampusResourceDetailViewController.swift; sourceTree = "<group>"; };
@@ -401,6 +405,7 @@
 				13491DB7241E22130033F9AB /* Colors+Event.swift */,
 				135D7F76243A9BD1003F8BD1 /* Colors+GymClass.swift */,
 				017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */,
+				01CDFF69257C614900D9FBD6 /* Colors+Resource.swift */,
 			);
 			path = Colors;
 			sourceTree = "<group>";
@@ -751,6 +756,7 @@
 			children = (
 				13B39A9423E6A3330039FBA2 /* ResourceDataSource.swift */,
 				553EF6AB2404E2C600D2955E /* Resource.swift */,
+				01CDFF66257C5F2300D9FBD6 /* ResourceType.swift */,
 			);
 			path = ResourcesDataSource;
 			sourceTree = "<group>";
@@ -984,6 +990,7 @@
 				5546CB91251B0A4500BE1876 /* UIDevice+Extensions.swift in Sources */,
 				2975D5402459301B00514B43 /* SearchDrawerViewDelegate.swift in Sources */,
 				133864A42404DCCA001F9048 /* MapMarker.swift in Sources */,
+				01CDFF67257C5F2300D9FBD6 /* ResourceType.swift in Sources */,
 				13491DBA241E23630033F9AB /* Colors+Text.swift in Sources */,
 				136DC97D2398B4F3009B1810 /* UIImage+Extensions.swift in Sources */,
 				55C6936B240E143500400B60 /* ResourceTableViewCell.swift in Sources */,
@@ -1088,6 +1095,7 @@
 				13491DB6241E21740033F9AB /* Colors+TagView.swift in Sources */,
 				556CCD2223E7771800F41BF9 /* MapPlacemark.swift in Sources */,
 				297678872426B7BA00FDD1EB /* SearchAnnotation.swift in Sources */,
+				01CDFF6A257C614900D9FBD6 /* Colors+Resource.swift in Sources */,
 				13741B6C2400D866003D1EEB /* MapDataSource.swift in Sources */,
 				1336A320241D924300949F32 /* DiningItem.swift in Sources */,
 				299ACFB4244A5F90000F3E86 /* HasOccupancy.swift in Sources */,

--- a/berkeley-mobile/Assets/Colors/Colors+Resource.swift
+++ b/berkeley-mobile/Assets/Colors/Colors+Resource.swift
@@ -1,0 +1,37 @@
+//
+//  Colors+Resource.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 12/5/20.
+//  Copyright © 2020 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension Color {
+    // Colors for Resource Types
+    struct Resource {
+
+        static var health: UIColor {
+            UIColor(displayP3Red: 225/255, green: 77/255, blue: 77/255, alpha: 0.89)
+        }
+
+        static var finances: UIColor {
+            UIColor(displayP3Red: 92/255, green: 198/255, blue: 175/255, alpha: 0.89)
+        }
+
+        static var admin: UIColor {
+            UIColor(displayP3Red: 114/255, green: 151/255, blue: 230/255, alpha: 0.89)
+        }
+
+        static var basicNeeds: UIColor {
+            UIColor(displayP3Red: 210/255, green: 95/255, blue: 223/255, alpha: 0.89)
+        }
+
+        static var legal: UIColor {
+            UIColor(displayP3Red: 247/255, green: 148/255, blue: 106/255, alpha: 0.89)
+        }
+    }
+
+}

--- a/berkeley-mobile/Common/ResourceTableViewCell.swift
+++ b/berkeley-mobile/Common/ResourceTableViewCell.swift
@@ -92,7 +92,8 @@ class ResourceTableViewCell: UITableViewCell, ImageViewCell {
     func cellConfigure(entry: Resource) {
         resourceName.text = entry.name
         
-        resourceCategory.text = "Resource"
+        resourceCategory.text = entry.type ?? "Resource"
+        resourceCategory.backgroundColor = entry.color
         
         cellImageView.image = UIImage(named: "DoeGlade")
     }

--- a/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
+++ b/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
@@ -31,13 +31,22 @@ class Resource: SearchItem, HasLocation, HasOpenTimes {
     let address: String?
     let description: String?
     var weeklyHours: WeeklyHours?
+
+    /// The category for this resource. See `ResourceType` for expected values.
+    var type: String?
+
+    /// The color associated with`type`. See `ResourceType` for provided colors.
+    var color: UIColor {
+        return ResourceType(rawValue: type ?? "")?.color ?? Color.eventDefault
+    }
     
-    init(name: String, address: String?, latitude: Double?, longitude: Double?, description: String?, hours: WeeklyHours?) {
+    init(name: String, address: String?, latitude: Double?, longitude: Double?, description: String?, hours: WeeklyHours?, type: String?) {
         self.name = name
         self.address = address
         self.latitude = latitude
         self.longitude = longitude
         self.description = description
         self.weeklyHours = hours
+        self.type = type
     }
 }

--- a/berkeley-mobile/Resources/ResourcesDataSource/ResourceDataSource.swift
+++ b/berkeley-mobile/Resources/ResourcesDataSource/ResourceDataSource.swift
@@ -41,7 +41,8 @@ class ResourceDataSource: DataSource {
                                             latitude: dict["latitude"] as? Double,
                                             longitude: dict["longitude"] as? Double,
                                             description: dict["description"] as? String,
-                                            hours: weeklyHours)
+                                            hours: weeklyHours,
+                                            type: dict["tag"] as? String)
         return campusResource
     }
 }

--- a/berkeley-mobile/Resources/ResourcesDataSource/ResourceType.swift
+++ b/berkeley-mobile/Resources/ResourcesDataSource/ResourceType.swift
@@ -1,0 +1,35 @@
+//
+//  ResourceType.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 12/5/20.
+//  Copyright © 2020 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+enum ResourceType: String {
+
+    case health = "Health"
+    case finances = "Finances"
+    case legal = "Legal"
+    case basicNeeds = "Basic Needs"
+    case admin = "Admin"
+
+    var color: UIColor {
+        switch self {
+        case .health:
+            return Color.Resource.health
+        case .finances:
+            return Color.Resource.finances
+        case .legal:
+            return Color.Resource.legal
+        case .basicNeeds:
+            return Color.Resource.basicNeeds
+        case .admin:
+            return Color.Resource.admin
+        }
+    }
+
+}


### PR DESCRIPTION
Add the `tag` field from Firebase to the campus-wide resources, and display tags with an associated color:
<img width="559" alt="Screen Shot 2020-12-05 at 5 17 50 PM" src="https://user-images.githubusercontent.com/41145903/101268960-1a04c980-371e-11eb-975d-1371196b8ab2.png">
- Adds `ResourceType.swift` for known values ("Health", "Finances", "Legal", "Basic Needs", "Admin") and colors. Unknown values will be displayed with the default, gray color.
