### PR TITLE
Split Resources Tab

### DIFF
--- a/berkeley-mobile/Assets/Colors/Colors.swift
+++ b/berkeley-mobile/Assets/Colors/Colors.swift
@@ -79,5 +79,9 @@ struct Color {
     static var barGraphEntryCurrent: UIColor {
         return UIColor(displayP3Red: 119/255, green: 154/255, blue: 252/255, alpha: 1.0)
     }
+
+    static var segmentedControlHighlight: UIColor {
+        return UIColor(displayP3Red: 250/255, green: 212/255, blue: 126/255, alpha: 1.0)
+    }
 }
 

--- a/berkeley-mobile/Common/SegmentedControl/SegmentedControlViewController.swift
+++ b/berkeley-mobile/Common/SegmentedControl/SegmentedControlViewController.swift
@@ -108,10 +108,6 @@ class SegmentedControlViewController: UIViewController {
         indicator.transform = CGAffineTransform(scaleX: -1, y: 1)
         indicator.backgroundColor = UIColor.white
         indicator.layer.cornerRadius = size.height / 2
-        indicator.layer.shadowRadius = 5
-        indicator.layer.shadowOpacity = 0.2
-        indicator.layer.shadowColor = UIColor.black.cgColor
-        indicator.layer.shadowOffset = CGSize(width: 0, height: 5)
 
         view.addSubview(indicator)
         indicator.translatesAutoresizingMaskIntoConstraints = false

--- a/berkeley-mobile/Common/SegmentedControl/SegmentedControlViewController.swift
+++ b/berkeley-mobile/Common/SegmentedControl/SegmentedControlViewController.swift
@@ -98,7 +98,7 @@ class SegmentedControlViewController: UIViewController {
         let nonzeroSize = CGSize(width: 1, height: kControlHeight)
         control = SegmentedControl(frame: CGRect(origin: .zero, size: scrollable ? nonzeroSize : size),
                                 barHeight: kBarHeight,
-                                barColor: Color.segemntedControlHighlight)
+                                barColor: Color.segmentedControlHighlight)
         control.delegate = self
         scrollView.addSubview(control)
         control.translatesAutoresizingMaskIntoConstraints = false

--- a/berkeley-mobile/Common/SegmentedControl/SegmentedControlViewController.swift
+++ b/berkeley-mobile/Common/SegmentedControl/SegmentedControlViewController.swift
@@ -108,6 +108,11 @@ class SegmentedControlViewController: UIViewController {
         indicator.transform = CGAffineTransform(scaleX: -1, y: 1)
         indicator.backgroundColor = UIColor.white
         indicator.layer.cornerRadius = size.height / 2
+        indicator.layer.shadowRadius = 5
+        indicator.layer.shadowOpacity = 0.25
+        indicator.layer.shadowOffset = .zero
+        indicator.layer.shadowColor = UIColor.black.cgColor
+        indicator.layer.shadowPath = UIBezierPath(rect: indicator.layer.bounds.insetBy(dx: 4, dy: 4)).cgPath
 
         view.addSubview(indicator)
         indicator.translatesAutoresizingMaskIntoConstraints = false

--- a/berkeley-mobile/Resources/Campus/CampusResourceViewController.swift
+++ b/berkeley-mobile/Resources/Campus/CampusResourceViewController.swift
@@ -17,15 +17,36 @@ class CampusResourceViewController: UIViewController {
     private var resourcesTable: FilterTableView = FilterTableView<Resource>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
     
     private var resourceEntries: [Resource] = []
-    
+
+    /// If non-nil, this view will present the filtered set of campus resources.
+    private var resourceFilter: ((Resource) -> Bool)?
+
+    convenience init() {
+        self.init(type: nil)
+    }
+
+    init(type: ResourceType?) {
+        super.init(nibName: nil, bundle: nil)
+        guard let type = type else { return }
+        resourceFilter = { resource in
+            return resource.type == type.rawValue
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
         setupResourcesList()
 
         DataManager.shared.fetch(source: ResourceDataSource.self) { resourceEntries in
-            self.resourceEntries = resourceEntries as? [Resource] ?? []
-            self.resourcesTable.setData(data: resourceEntries as! [Resource])
+            var entries = resourceEntries as? [Resource] ?? []
+            if let filter = self.resourceFilter { entries = entries.filter(filter) }
+            self.resourceEntries = entries
+            self.resourcesTable.setData(data: self.resourceEntries)
             self.resourcesTable.update()
         }
     }

--- a/berkeley-mobile/Resources/ResourcesDataSource/ResourceType.swift
+++ b/berkeley-mobile/Resources/ResourcesDataSource/ResourceType.swift
@@ -12,8 +12,6 @@ import UIKit
 enum ResourceType: String {
 
     case health = "Health"
-    case finances = "Finances"
-    case legal = "Legal"
     case basicNeeds = "Basic Needs"
     case admin = "Admin"
 
@@ -21,10 +19,6 @@ enum ResourceType: String {
         switch self {
         case .health:
             return Color.Resource.health
-        case .finances:
-            return Color.Resource.finances
-        case .legal:
-            return Color.Resource.legal
         case .basicNeeds:
             return Color.Resource.basicNeeds
         case .admin:

--- a/berkeley-mobile/Resources/ResourcesViewController.swift
+++ b/berkeley-mobile/Resources/ResourcesViewController.swift
@@ -65,8 +65,10 @@ extension ResourcesViewController {
             Page(viewController: CovidResourceViewController(), label: "COVID-19"),
             Page(viewController: CampusResourceViewController(type: .basicNeeds), label: "Basic Needs"),
             Page(viewController: CampusResourceViewController(type: .health), label: "Health"),
-            Page(viewController: CampusResourceViewController(type: .admin), label: "Admin")
-        ], controlInsets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: blobImageView.frame.width / 4),
+            Page(viewController: CampusResourceViewController(type: .admin), label: "Admin"),
+            Page(viewController: CampusResourceViewController(type: .admin), label: "Other")
+        ], controlInsets: UIEdgeInsets(top: 0, left: view.layoutMargins.left,
+                                       bottom: 0, right: blobImageView.frame.width / 4),
            centerControl: false, scrollable: true)
         segmentedControl.control.sizeEqually = false
         self.add(child: segmentedControl)

--- a/berkeley-mobile/Resources/ResourcesViewController.swift
+++ b/berkeley-mobile/Resources/ResourcesViewController.swift
@@ -63,8 +63,12 @@ extension ResourcesViewController {
         // Don't add this padding for now.
         let segmentedControl = SegmentedControlViewController(pages: [
             Page(viewController: CovidResourceViewController(), label: "COVID-19"),
-            Page(viewController: CampusResourceViewController(), label: "Campus-Wide")
-        ], controlInsets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: blobImageView.frame.width / 4), centerControl: false)
+            Page(viewController: CampusResourceViewController(type: .basicNeeds), label: "Basic Needs"),
+            Page(viewController: CampusResourceViewController(type: .health), label: "Health"),
+            Page(viewController: CampusResourceViewController(type: .admin), label: "Admin")
+        ], controlInsets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: blobImageView.frame.width / 4),
+           centerControl: false, scrollable: true)
+        segmentedControl.control.sizeEqually = false
         self.add(child: segmentedControl)
         segmentedControl.view.translatesAutoresizingMaskIntoConstraints = false
         segmentedControl.view.topAnchor.constraint(equalTo: resourcesLabel.bottomAnchor, constant: kViewMargin).isActive = true

--- a/berkeley-mobile/Resources/ResourcesViewController.swift
+++ b/berkeley-mobile/Resources/ResourcesViewController.swift
@@ -63,10 +63,13 @@ extension ResourcesViewController {
         // Don't add this padding for now.
         let segmentedControl = SegmentedControlViewController(pages: [
             Page(viewController: CovidResourceViewController(), label: "COVID-19"),
-            Page(viewController: CampusResourceViewController(type: .basicNeeds), label: "Basic Needs"),
             Page(viewController: CampusResourceViewController(type: .health), label: "Health"),
             Page(viewController: CampusResourceViewController(type: .admin), label: "Admin"),
-            Page(viewController: CampusResourceViewController(type: .admin), label: "Other")
+            Page(viewController: CampusResourceViewController(type: .basicNeeds), label: "Basic Needs"),
+            Page(viewController: CampusResourceViewController(
+                type: nil,
+                notIn: Set<ResourceType>([.health, .admin, .basicNeeds])
+            ), label: "Other")
         ], controlInsets: UIEdgeInsets(top: 0, left: view.layoutMargins.left,
                                        bottom: 0, right: blobImageView.frame.width / 4),
            centerControl: false, scrollable: true)


### PR DESCRIPTION
Splits the Campus-Wide tab of the Resources tab into three distinct tags: `Basic Needs`, `Health`, `Admin` (in that order). Would like feedback about this change:
- Ordering of the categories.
- Would we want to not hardcode these categories in the case that new ones are added to the backend, or is that not a concern and having deliberate ordering is preferable?
- How does the scrolling of the segmented control feel / is it intuitive, or will many users not know that there may be obscured options? On the iPhone 12 Pro, `Admin` is completely cut off, and I'm not sure how to indicate to users that there are more pages.

## Description

Since the additional buttons flow off the edge of the screen for small screens, users can scroll through the options of the `SegmentedControl` horizontally.
- Adds the public `sizeEqually` and `spacing` variables to `SegmentedControl`.
  - When `sizeEqually` is `false`, the control will size the widths of the segments based on their text lengths, rather than having equal-sized segments that shrink the font size of longer labels when there is no room (previous behavior).
  - The `spacing` value is only used when `sizeEqually` is `false`, and determines the margins between segments.
- If the user swipes to a page whose label is cut-off in the segmented control, automatically scroll the segmented control to display the full text.

Splits the Resources tab into `Basic Needs`, `Health`, and `Admin`.
- Removes the `.finances` and `.legal` types from the `ResourceType` enum.
- Changes `CampusResourceViewController` to display only the filtered resources of a single type.

## After

<img width="559" alt="Screen Shot 2021-01-25 at 10 07 15 PM" src="https://user-images.githubusercontent.com/41145903/105806908-b5196300-5f59-11eb-9d1c-ebeefc79d1a9.png">

