### PR TITLE
JSON Parsing w/ Decodable - Proof of Concept

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -11,7 +11,10 @@
 		016A56D6251AD38F00531A12 /* CalendarEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A56D5251AD38F00531A12 /* CalendarEvent.swift */; };
 		016A56D8251C930D00531A12 /* AppDelegate+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A56D7251C930D00531A12 /* AppDelegate+Migration.swift */; };
 		017C0B26251018BA00BFA80A /* Colors+MapMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */; };
-		0181710525CA770A00BA6317 /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181710425CA770A00BA6317 /* Course.swift */; };
+		0181710525CA770A00BA6317 /* BTCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181710425CA770A00BA6317 /* BTCourse.swift */; };
+		0181710A25CA90D300BA6317 /* AuthenticateUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181710925CA90D300BA6317 /* AuthenticateUser.swift */; };
+		0181711125CAA3B300BA6317 /* AnyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181711025CAA3B300BA6317 /* AnyJSON.swift */; };
+		0181711725CAABB000BA6317 /* AddClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181711625CAABB000BA6317 /* AddClass.swift */; };
 		018B982625327358004C3B26 /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982525327358004C3B26 /* ActionButton.swift */; };
 		018B982825328200004C3B26 /* Colors+ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982725328200004C3B26 /* Colors+ActionButton.swift */; };
 		01B250282516AD4F00CBA459 /* IconPairView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B250272516AD4F00CBA459 /* IconPairView.swift */; };
@@ -190,7 +193,10 @@
 		016A56D5251AD38F00531A12 /* CalendarEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEvent.swift; sourceTree = "<group>"; };
 		016A56D7251C930D00531A12 /* AppDelegate+Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Migration.swift"; sourceTree = "<group>"; };
 		017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+MapMarker.swift"; sourceTree = "<group>"; };
-		0181710425CA770A00BA6317 /* Course.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
+		0181710425CA770A00BA6317 /* BTCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCourse.swift; sourceTree = "<group>"; };
+		0181710925CA90D300BA6317 /* AuthenticateUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticateUser.swift; sourceTree = "<group>"; };
+		0181711025CAA3B300BA6317 /* AnyJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyJSON.swift; sourceTree = "<group>"; };
+		0181711625CAABB000BA6317 /* AddClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddClass.swift; sourceTree = "<group>"; };
 		018B982525327358004C3B26 /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
 		018B982725328200004C3B26 /* Colors+ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+ActionButton.swift"; sourceTree = "<group>"; };
 		01B250272516AD4F00CBA459 /* IconPairView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconPairView.swift; sourceTree = "<group>"; };
@@ -397,8 +403,10 @@
 		01CDBBE725CA6AEA006B93BD /* Schema */ = {
 			isa = PBXGroup;
 			children = (
-				0181710425CA770A00BA6317 /* Course.swift */,
+				0181710425CA770A00BA6317 /* BTCourse.swift */,
 				29DB64D125BA6269001C4275 /* StudyGroup.swift */,
+				0181711625CAABB000BA6317 /* AddClass.swift */,
+				0181710925CA90D300BA6317 /* AuthenticateUser.swift */,
 			);
 			path = Schema;
 			sourceTree = "<group>";
@@ -409,6 +417,7 @@
 				01CDBBC625CA3B13006B93BD /* NetworkManager.swift */,
 				01CDBBEC25CA6F4D006B93BD /* Response.swift */,
 				01CDBBF025CA6F58006B93BD /* RequestError.swift */,
+				0181711025CAA3B300BA6317 /* AnyJSON.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1192,6 +1201,7 @@
 				29EF1F0325C79111000C0F97 /* ReviewPreferencesViewController.swift in Sources */,
 				55DCF79D237243F5001B01B8 /* RippleLayer.swift in Sources */,
 				132087AF23F3B05D00AE273C /* Filter.swift in Sources */,
+				0181711125CAA3B300BA6317 /* AnyJSON.swift in Sources */,
 				2925D5FC2529546A00BBA266 /* CampusEventCollectionViewCell.swift in Sources */,
 				556DB0DF23E7F60900F12721 /* ResourcesViewController.swift in Sources */,
 				296DDEC1253BB117008E8940 /* CampusEventDetailViewController.swift in Sources */,
@@ -1250,7 +1260,7 @@
 				13EA64D02399D50C00FD8E13 /* DataManager.swift in Sources */,
 				29B3A1742439A60A00093750 /* DiningMenuCell.swift in Sources */,
 				1336A326241D9B9900949F32 /* DiningHall.swift in Sources */,
-				0181710525CA770A00BA6317 /* Course.swift in Sources */,
+				0181710525CA770A00BA6317 /* BTCourse.swift in Sources */,
 				29061D41241C450E002BC9D9 /* HasLocation.swift in Sources */,
 				1336A31A241C3FD300949F32 /* GymClassDataSource.swift in Sources */,
 				29387E9524BBBC1000070BCE /* BarGraph.swift in Sources */,
@@ -1287,6 +1297,8 @@
 				13741B6C2400D866003D1EEB /* MapDataSource.swift in Sources */,
 				1336A320241D924300949F32 /* DiningItem.swift in Sources */,
 				299ACFB4244A5F90000F3E86 /* HasOccupancy.swift in Sources */,
+				0181710A25CA90D300BA6317 /* AuthenticateUser.swift in Sources */,
+				0181711725CAABB000BA6317 /* AddClass.swift in Sources */,
 				559A7B6D2373DEFA004EA501 /* MaterialTableViewCell.swift in Sources */,
 				29891B23257C521E0094891D /* PageViewController.swift in Sources */,
 				13EA64CD2399CEDA00FD8E13 /* Gym.swift in Sources */,

--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0181710A25CA90D300BA6317 /* AuthenticateUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181710925CA90D300BA6317 /* AuthenticateUser.swift */; };
 		0181711125CAA3B300BA6317 /* AnyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181711025CAA3B300BA6317 /* AnyJSON.swift */; };
 		0181711725CAABB000BA6317 /* AddClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181711625CAABB000BA6317 /* AddClass.swift */; };
+		0181711C25CB506A00BA6317 /* Encodable+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181711B25CB506A00BA6317 /* Encodable+JSON.swift */; };
 		018B982625327358004C3B26 /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982525327358004C3B26 /* ActionButton.swift */; };
 		018B982825328200004C3B26 /* Colors+ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982725328200004C3B26 /* Colors+ActionButton.swift */; };
 		01B250282516AD4F00CBA459 /* IconPairView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B250272516AD4F00CBA459 /* IconPairView.swift */; };
@@ -197,6 +198,7 @@
 		0181710925CA90D300BA6317 /* AuthenticateUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticateUser.swift; sourceTree = "<group>"; };
 		0181711025CAA3B300BA6317 /* AnyJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyJSON.swift; sourceTree = "<group>"; };
 		0181711625CAABB000BA6317 /* AddClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddClass.swift; sourceTree = "<group>"; };
+		0181711B25CB506A00BA6317 /* Encodable+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+JSON.swift"; sourceTree = "<group>"; };
 		018B982525327358004C3B26 /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
 		018B982725328200004C3B26 /* Colors+ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+ActionButton.swift"; sourceTree = "<group>"; };
 		01B250272516AD4F00CBA459 /* IconPairView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconPairView.swift; sourceTree = "<group>"; };
@@ -417,6 +419,7 @@
 				01CDBBC625CA3B13006B93BD /* NetworkManager.swift */,
 				01CDBBEC25CA6F4D006B93BD /* Response.swift */,
 				01CDBBF025CA6F58006B93BD /* RequestError.swift */,
+				0181711B25CB506A00BA6317 /* Encodable+JSON.swift */,
 				0181711025CAA3B300BA6317 /* AnyJSON.swift */,
 			);
 			path = Network;
@@ -1232,6 +1235,7 @@
 				29DB64D225BA6269001C4275 /* StudyGroup.swift in Sources */,
 				29345E2B24A7EC2B00859A88 /* HasImage.swift in Sources */,
 				2913595924B13DF200DE9AD6 /* OpenTimesCardView.swift in Sources */,
+				0181711C25CB506A00BA6317 /* Encodable+JSON.swift in Sources */,
 				13135BB3241244370056B169 /* FilterViewCell.swift in Sources */,
 				552F4A4C254E13BF0061D0F2 /* CampusResourceViewController.swift in Sources */,
 				016A56D42519E96800531A12 /* CampusCalendarViewController.swift in Sources */,

--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		016A56D6251AD38F00531A12 /* CalendarEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A56D5251AD38F00531A12 /* CalendarEvent.swift */; };
 		016A56D8251C930D00531A12 /* AppDelegate+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A56D7251C930D00531A12 /* AppDelegate+Migration.swift */; };
 		017C0B26251018BA00BFA80A /* Colors+MapMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */; };
+		0181710525CA770A00BA6317 /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181710425CA770A00BA6317 /* Course.swift */; };
 		018B982625327358004C3B26 /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982525327358004C3B26 /* ActionButton.swift */; };
 		018B982825328200004C3B26 /* Colors+ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982725328200004C3B26 /* Colors+ActionButton.swift */; };
 		01B250282516AD4F00CBA459 /* IconPairView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B250272516AD4F00CBA459 /* IconPairView.swift */; };
@@ -19,6 +20,10 @@
 		01BC8EB024E8C3E3005B4969 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BC8EAF24E8C3E3005B4969 /* DetailView.swift */; };
 		01C75E2E25292E5B00C25A32 /* DescriptionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C75E2D25292E5B00C25A32 /* DescriptionCardView.swift */; };
 		01CDBB9925CA32AF006B93BD /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBB9825CA32AF006B93BD /* Secrets.swift */; };
+		01CDBBC725CA3B13006B93BD /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBBC625CA3B13006B93BD /* NetworkManager.swift */; };
+		01CDBBE925CA6AF9006B93BD /* StudyPact+Endpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBBE825CA6AF9006B93BD /* StudyPact+Endpoints.swift */; };
+		01CDBBED25CA6F4D006B93BD /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBBEC25CA6F4D006B93BD /* Response.swift */; };
+		01CDBBF125CA6F58006B93BD /* RequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBBF025CA6F58006B93BD /* RequestError.swift */; };
 		01CDFF67257C5F2300D9FBD6 /* ResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDFF66257C5F2300D9FBD6 /* ResourceType.swift */; };
 		01CDFF6A257C614900D9FBD6 /* Colors+Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDFF69257C614900D9FBD6 /* Colors+Resource.swift */; };
 		01D11B8E2504453B00BDF660 /* ScrollingStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D11B8D2504453B00BDF660 /* ScrollingStackView.swift */; };
@@ -185,6 +190,7 @@
 		016A56D5251AD38F00531A12 /* CalendarEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEvent.swift; sourceTree = "<group>"; };
 		016A56D7251C930D00531A12 /* AppDelegate+Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Migration.swift"; sourceTree = "<group>"; };
 		017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+MapMarker.swift"; sourceTree = "<group>"; };
+		0181710425CA770A00BA6317 /* Course.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
 		018B982525327358004C3B26 /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
 		018B982725328200004C3B26 /* Colors+ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+ActionButton.swift"; sourceTree = "<group>"; };
 		01B250272516AD4F00CBA459 /* IconPairView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconPairView.swift; sourceTree = "<group>"; };
@@ -193,6 +199,10 @@
 		01BC8EAF24E8C3E3005B4969 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		01C75E2D25292E5B00C25A32 /* DescriptionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionCardView.swift; sourceTree = "<group>"; };
 		01CDBB9825CA32AF006B93BD /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
+		01CDBBC625CA3B13006B93BD /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		01CDBBE825CA6AF9006B93BD /* StudyPact+Endpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StudyPact+Endpoints.swift"; sourceTree = "<group>"; };
+		01CDBBEC25CA6F4D006B93BD /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		01CDBBF025CA6F58006B93BD /* RequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestError.swift; sourceTree = "<group>"; };
 		01CDFF66257C5F2300D9FBD6 /* ResourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceType.swift; sourceTree = "<group>"; };
 		01CDFF69257C614900D9FBD6 /* Colors+Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+Resource.swift"; sourceTree = "<group>"; };
 		01D11B8D2504453B00BDF660 /* ScrollingStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingStackView.swift; sourceTree = "<group>"; };
@@ -375,6 +385,34 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01CDBBE625CA6ADD006B93BD /* API */ = {
+			isa = PBXGroup;
+			children = (
+				01CDBBE725CA6AEA006B93BD /* Schema */,
+				01CDBBE825CA6AF9006B93BD /* StudyPact+Endpoints.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
+		01CDBBE725CA6AEA006B93BD /* Schema */ = {
+			isa = PBXGroup;
+			children = (
+				0181710425CA770A00BA6317 /* Course.swift */,
+				29DB64D125BA6269001C4275 /* StudyGroup.swift */,
+			);
+			path = Schema;
+			sourceTree = "<group>";
+		};
+		01CDBBEB25CA6F3D006B93BD /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				01CDBBC625CA3B13006B93BD /* NetworkManager.swift */,
+				01CDBBEC25CA6F4D006B93BD /* Response.swift */,
+				01CDBBF025CA6F58006B93BD /* RequestError.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
 		1336A31D241C400F00949F32 /* GymClassDataSource */ = {
 			isa = PBXGroup;
 			children = (
@@ -596,6 +634,7 @@
 		13EA64CE2399D4A100FD8E13 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				01CDBBEB25CA6F3D006B93BD /* Network */,
 				299ACFAE244A58A8000F3E86 /* Occupancy */,
 				13B8E95724256E4F00E7FCBF /* ItemProtocols */,
 				13EA64CF2399D50C00FD8E13 /* DataManager.swift */,
@@ -710,7 +749,6 @@
 				29DB64CE25BA61BD001C4275 /* StudyGroupsView.swift */,
 				29DB64D825BA8242001C4275 /* AllStudyGroupsViewController.swift */,
 				29A6610025C4EA6A004D2FC2 /* PendingGroupViewController.swift */,
-				29DB64D125BA6269001C4275 /* StudyGroup.swift */,
 			);
 			path = StudyGroups;
 			sourceTree = "<group>";
@@ -830,6 +868,7 @@
 		55208DF025B7D93E00A75983 /* StudyPact */ = {
 			isa = PBXGroup;
 			children = (
+				01CDBBE625CA6ADD006B93BD /* API */,
 				2978F25825CA50670010E3BA /* StudyPact.swift */,
 				29EF1EF625C76BB8000C0F97 /* CreatePreference */,
 				29EF1EF525C76BAB000C0F97 /* Profile */,
@@ -1104,6 +1143,7 @@
 				55AF44292453A4EC00F13232 /* CafeDataSource.swift in Sources */,
 				29DB64CF25BA61BD001C4275 /* StudyGroupsView.swift in Sources */,
 				306A550023614C0000D59A7F /* MainContainerViewController.swift in Sources */,
+				01CDBBE925CA6AF9006B93BD /* StudyPact+Endpoints.swift in Sources */,
 				2978F20625CA4C680010E3BA /* BorderedTextField.swift in Sources */,
 				29F11EC72516C150007DCFD7 /* BarView.swift in Sources */,
 				55DCF78723722CBD001B01B8 /* Colors.swift in Sources */,
@@ -1118,6 +1158,7 @@
 				557756692544D822009C03BD /* Collection+Extension.swift in Sources */,
 				5546CB91251B0A4500BE1876 /* UIDevice+Extensions.swift in Sources */,
 				2975D5402459301B00514B43 /* SearchDrawerViewDelegate.swift in Sources */,
+				01CDBBED25CA6F4D006B93BD /* Response.swift in Sources */,
 				133864A42404DCCA001F9048 /* MapMarker.swift in Sources */,
 				01CDFF67257C5F2300D9FBD6 /* ResourceType.swift in Sources */,
 				13491DBA241E23630033F9AB /* Colors+Text.swift in Sources */,
@@ -1209,6 +1250,7 @@
 				13EA64D02399D50C00FD8E13 /* DataManager.swift in Sources */,
 				29B3A1742439A60A00093750 /* DiningMenuCell.swift in Sources */,
 				1336A326241D9B9900949F32 /* DiningHall.swift in Sources */,
+				0181710525CA770A00BA6317 /* Course.swift in Sources */,
 				29061D41241C450E002BC9D9 /* HasLocation.swift in Sources */,
 				1336A31A241C3FD300949F32 /* GymClassDataSource.swift in Sources */,
 				29387E9524BBBC1000070BCE /* BarGraph.swift in Sources */,
@@ -1216,6 +1258,7 @@
 				2925D5FA2529405500BBA266 /* CampusEventCellView.swift in Sources */,
 				5516088624392E5100B1E55B /* DiningViewController.swift in Sources */,
 				FD6FB45C25C62EB90045A03A /* SelectLocationView.swift in Sources */,
+				01CDBBC725CA3B13006B93BD /* NetworkManager.swift in Sources */,
 				018B982825328200004C3B26 /* Colors+ActionButton.swift in Sources */,
 				296B8AA72544D97F00C3A219 /* EventOverviewCardView.swift in Sources */,
 				29387E9B24BBBD9D00070BCE /* CALayerExtension.swift in Sources */,
@@ -1225,6 +1268,7 @@
 				01D11B8E2504453B00BDF660 /* ScrollingStackView.swift in Sources */,
 				29387E9924BBBC9300070BCE /* BarEntry+DataEntry.swift in Sources */,
 				306A54EC23613E3A00D59A7F /* SceneDelegate.swift in Sources */,
+				01CDBBF125CA6F58006B93BD /* RequestError.swift in Sources */,
 				01FA50F124E8B33100DCC490 /* LocationManager.swift in Sources */,
 				017C0B26251018BA00BFA80A /* Colors+MapMarker.swift in Sources */,
 				29345E2724A7E76300859A88 /* OverviewCardView.swift in Sources */,

--- a/berkeley-mobile/Data/Network/AnyJSON.swift
+++ b/berkeley-mobile/Data/Network/AnyJSON.swift
@@ -1,0 +1,70 @@
+//
+//  AnyJSON.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 2/3/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+enum JSONType: CaseIterable {
+    case null
+    case int
+    case double
+    case string
+    case bool
+    case array
+    case dictionary
+}
+
+struct AnyJSON: Decodable {
+
+    private let value: Any?
+    private let type: JSONType
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        var object: Any?
+        var type: JSONType = .null
+        for _type in JSONType.allCases {
+            type = _type
+            switch type {
+            case .int:
+                object = try? container.decode(Int.self)
+            case .double:
+                object = try? container.decode(Double.self)
+            case .string:
+                object = try? container.decode(String.self)
+            case .bool:
+                object = try? container.decode(Bool.self)
+            case .array:
+                object = try? container.decode([AnyJSON].self)
+            case .dictionary:
+                object = try? container.decode([String: AnyJSON].self)
+            default:
+                break
+            }
+
+            if object != nil { break }
+        }
+
+        self.value = object
+        self.type = object == nil ? .null : type
+    }
+
+    public var unwrapped: Any? {
+        guard let value = value else { return nil }
+        switch type {
+        case .dictionary:
+            guard let dict = value as? [String: AnyJSON] else { return nil }
+            return dict.mapValues { $0.unwrapped }
+        case .array:
+            guard let arr = value as? [AnyJSON] else { return nil }
+            return arr.map { $0.unwrapped }
+        default:
+            return value
+        }
+    }
+}

--- a/berkeley-mobile/Data/Network/Encodable+JSON.swift
+++ b/berkeley-mobile/Data/Network/Encodable+JSON.swift
@@ -1,0 +1,17 @@
+//
+//  Encodable+JSON.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 2/3/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+extension Encodable {
+    var asJSON: JSONObject? {
+        let encoder = JSONEncoder()
+        do { return try JSONSerialization.jsonObject(with: encoder.encode(self)) as? JSONObject }
+        catch { return nil }
+    }
+}

--- a/berkeley-mobile/Data/Network/NetworkManager.swift
+++ b/berkeley-mobile/Data/Network/NetworkManager.swift
@@ -1,0 +1,128 @@
+//
+//  NetworkManager.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 2/2/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+typealias Nonce = URLSessionDataTask
+
+// MARK: - NetworkManager
+
+class NetworkManager {
+
+    /// Singleton instance.
+    static let shared = NetworkManager()
+
+    /// The `URLSession` used by this class to executre requests.
+    private var session: URLSession = URLSession.shared
+
+    // MARK: - GET Requests
+
+    @discardableResult
+    private func _get<T>(url: URL, params: [String: String],
+                         decode: @escaping (Data) throws -> T,
+                         completion: @escaping (Response<T>) -> Void) -> Nonce? {
+        guard let url = parameterize(url, with: params) else {
+            completion(.failure(error: RequestError.badURL))
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        let task = session.dataTask(with: request) { data, response, error in
+            self.responseHandler(data: data, response: response, error: error,
+                                 decode: decode, completion: completion)
+        }
+        task.resume()
+        return task
+    }
+
+    @discardableResult
+    open func get<T: Decodable>(url: URL, params: [String: String], asType: T.Type,
+                                completion: @escaping (Response<T>) -> Void) -> Nonce? {
+        return _get(url: url, params: params, decode: { data in
+            return try JSONDecoder().decode(T.self, from: data)
+        }, completion: completion)
+    }
+
+    @discardableResult
+    open func get(url: URL, params: [String: String],
+                  completion: @escaping (Response<[String: Any]>) -> Void) -> Nonce? {
+        return _get(url: url, params: params, decode: { data in
+            guard let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw RequestError.decodeFailure(data: data)
+            }
+            return dict
+        }, completion: completion)
+    }
+
+    // MARK: - POST Requests
+
+    private func _post<T>(url: URL, body: [String: String],
+                          decode: @escaping (Data) throws -> T,
+                          completion: @escaping (Response<T>) -> Void) -> Nonce? {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+        let task = session.dataTask(with: request) { data, response, error in
+            self.responseHandler(data: data, response: response, error: error,
+                                 decode: decode, completion: completion)
+        }
+        task.resume()
+        return task
+    }
+
+    @discardableResult
+    open func post<T: Decodable>(url: URL, body: [String: String], asType: T.Type,
+                                 completion: @escaping (Response<T>) -> Void) -> Nonce? {
+        return _post(url: url, body: body, decode: { data in
+            return try JSONDecoder().decode(T.self, from: data)
+        }, completion: completion)
+    }
+
+    @discardableResult
+    open func post(url: URL, body: [String: String],
+                   completion: @escaping (Response<[String: Any]>) -> Void) -> Nonce? {
+        return _post(url: url, body: body, decode: { data in
+            guard let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw RequestError.decodeFailure(data: data)
+            }
+            return dict
+        }, completion: completion)
+    }
+
+    // MARK: - Response Handler
+
+    @inline(__always) private func responseHandler<T>(data: Data?, response: URLResponse?, error: Error?,
+                                                      decode: (Data) throws -> T,
+                                                      completion: @escaping (Response<T>) -> Void) {
+        if let error = error {
+            completion(.failure(error: error))
+        } else if let response = response as? HTTPURLResponse,
+                  response.statusCode != 200 {
+            completion(.failure(error: RequestError.badResponse(code: response.statusCode)))
+        } else {
+            guard let data = data else {
+                completion(.success(data: nil))
+                return
+            }
+            do {
+                let decoded = try decode(data)
+                completion(.success(data: decoded))
+            } catch {
+                completion(.failure(error: RequestError.decodeFailure(data: data)))
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func parameterize(_ url: URL, with params: [String: String]) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return nil }
+        components.queryItems = params.map { k, v in URLQueryItem(name: k, value: v) }
+        return components.url
+    }
+}

--- a/berkeley-mobile/Data/Network/RequestError.swift
+++ b/berkeley-mobile/Data/Network/RequestError.swift
@@ -1,0 +1,22 @@
+//
+//  RequestError.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 2/2/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+/// An error that occurs while attempting a HTTP request through `NetworkManager`.
+enum RequestError: Error {
+
+    /// The target URL or parameters are malformed.
+    case badURL
+
+    /// A 200 status code was not recieved.
+    case badResponse(code: Int)
+    
+    /// Unable to properly parse the response.
+    case decodeFailure(data: Data)
+}

--- a/berkeley-mobile/Data/Network/Response.swift
+++ b/berkeley-mobile/Data/Network/Response.swift
@@ -1,0 +1,19 @@
+//
+//  Response.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 2/2/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+/// An enum describing responses from network requests.
+enum Response<T> {
+
+    /// A HTTP status code of 200, and any returned data.
+    case success(data: T?)
+
+    /// A HTTP status code other than 200.
+    case failure(error: Error)
+}

--- a/berkeley-mobile/StudyPact/API/Schema/AddClass.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/AddClass.swift
@@ -30,6 +30,6 @@ struct AddClassParams: Encodable {
         self.cryptohash = cryptohash
         self.className = className
         self.size = size
-        self.env = isVirtual ? "Virtual" : "In Person"
+        self.env = isVirtual ? "virtual" : "in-person"
     }
 }

--- a/berkeley-mobile/StudyPact/API/Schema/AddClass.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/AddClass.swift
@@ -1,0 +1,35 @@
+//
+//  AddClass.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 2/3/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+struct AddClassParams: Encodable {
+    let email: String
+    let cryptohash: String
+    let className: String
+    let size: Int
+    let env: String
+
+    enum CodingKeys: String, CodingKey {
+        case email = "user_email", cryptohash = "secret_token",
+             className = "class_name", size, env
+    }
+
+    init?(email: String, cryptohash: String, prefs: StudyPactPreference) {
+        guard let className = prefs.className,
+              let size = prefs.numberOfPeople,
+              let isVirtual = prefs.isVirtual else {
+            return nil
+        }
+        self.email = email
+        self.cryptohash = cryptohash
+        self.className = className
+        self.size = size
+        self.env = isVirtual ? "Virtual" : "In Person"
+    }
+}

--- a/berkeley-mobile/StudyPact/API/Schema/AuthenticateUser.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/AuthenticateUser.swift
@@ -8,15 +8,6 @@
 
 import Foundation
 
-struct AuthenticateUserParams: Encodable {
-    let email: String
-    let cryptohash: String
-
-    enum CodingKeys: String, CodingKey {
-        case email = "Email", cryptohash = "CryptoHash"
-    }
-}
-
 struct AuthenticateUserDocument: Decodable {
     let valid: Bool
     let _info: AnyJSON

--- a/berkeley-mobile/StudyPact/API/Schema/AuthenticateUser.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/AuthenticateUser.swift
@@ -1,0 +1,29 @@
+//
+//  AuthenticateUser.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 2/3/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+struct AuthenticateUserParams: Encodable {
+    let email: String
+    let cryptohash: String
+
+    enum CodingKeys: String, CodingKey {
+        case email = "Email", cryptohash = "CryptoHash"
+    }
+}
+
+struct AuthenticateUserDocument: Decodable {
+    let valid: Bool
+    let _info: AnyJSON
+
+    var info: JSONObject? { _info.unwrapped as? JSONObject }
+
+    enum CodingKeys: String, CodingKey {
+        case valid = "isValid", _info = "UserInfo"
+    }
+}

--- a/berkeley-mobile/StudyPact/API/Schema/BTCourse.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/BTCourse.swift
@@ -1,5 +1,5 @@
 //
-//  Course.swift
+//  BTCourse.swift
 //  berkeley-mobile
 //
 //  Created by Kevin Hu on 2/2/21.

--- a/berkeley-mobile/StudyPact/API/Schema/Course.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/Course.swift
@@ -1,0 +1,24 @@
+//
+//  Course.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 2/2/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+extension StudyPact {
+    struct CoursesDocument: Decodable {
+        let courses: [Course]
+    }
+
+    struct Course: Decodable {
+        let number: String
+        let abbreviation: String
+
+        enum CodingKeys: String, CodingKey {
+            case number = "course_number", abbreviation
+        }
+    }
+}

--- a/berkeley-mobile/StudyPact/API/Schema/Course.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/Course.swift
@@ -8,17 +8,15 @@
 
 import Foundation
 
-extension StudyPact {
-    struct CoursesDocument: Decodable {
-        let courses: [Course]
-    }
+struct CoursesDocument: Decodable {
+    let courses: [Course]
+}
 
-    struct Course: Decodable {
-        let number: String
-        let abbreviation: String
+struct Course: Decodable {
+    let number: String
+    let abbreviation: String
 
-        enum CodingKeys: String, CodingKey {
-            case number = "course_number", abbreviation
-        }
+    enum CodingKeys: String, CodingKey {
+        case number = "course_number", abbreviation
     }
 }

--- a/berkeley-mobile/StudyPact/API/Schema/StudyGroup.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/StudyGroup.swift
@@ -8,16 +8,25 @@
 
 import UIKit
 
-struct StudyGroup {
+struct StudyGroup: Decodable {
     let className: String
     let groupMembers: [StudyGroupMember]
     let pending: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case className = "class_name", groupMembers = "users", pending
+    }
 }
 
-struct StudyGroupMember {
+struct StudyGroupMember: Decodable {
     let profilePictureURL: URL?
     let name: String
     let email: String
     let phoneNumber: String?
     let facebookUsername: String?
+
+    enum CodingKeys: String, CodingKey {
+        case profilePictureURL = "profile_picture", name, email,
+             phoneNumber = "phone", facebookUsername = "facebook"
+    }
 }

--- a/berkeley-mobile/StudyPact/API/StudyPact+Endpoints.swift
+++ b/berkeley-mobile/StudyPact/API/StudyPact+Endpoints.swift
@@ -1,0 +1,22 @@
+//
+//  StudyPact+Endpoints.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 2/2/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+extension StudyPact {
+    enum EndpointKey: String {
+        case registerUser = "REGISTER_USER"
+        case authenticateUser = "AUTHENTICATE_USER"
+        case getUser = "GET_USER"
+        case addUser = "ADD_USER"
+        case addClass = "ADD_CLASS"
+        case cancelPending = "CANCEL_PENDING"
+        case leaveGroup = "LEAVE_GROUP"
+        case getGroups = "GET_GROUPS"
+    }
+}

--- a/berkeley-mobile/StudyPact/API/StudyPact+Endpoints.swift
+++ b/berkeley-mobile/StudyPact/API/StudyPact+Endpoints.swift
@@ -18,5 +18,9 @@ extension StudyPact {
         case cancelPending = "CANCEL_PENDING"
         case leaveGroup = "LEAVE_GROUP"
         case getGroups = "GET_GROUPS"
+
+        public var url: URL? {
+            return URL(string: API_URLS[rawValue] ?? "")
+        }
     }
 }

--- a/berkeley-mobile/StudyPact/StudyPact.swift
+++ b/berkeley-mobile/StudyPact/StudyPact.swift
@@ -85,8 +85,8 @@ class StudyPact {
             completion(false)
             return
         }
-        let params = AuthenticateUserParams(email: email, cryptohash: cryptohash)
-        NetworkManager.shared.get(url: url, params: params, asType: AuthenticateUserDocument.self) { response in
+        let params = ["Email": email, "CryptoHash": cryptohash]
+        NetworkManager.shared.post(url: url, body: params, asType: AuthenticateUserDocument.self) { response in
             switch response {
             case .success(let data):
                 completion(data?.valid ?? false)
@@ -102,11 +102,11 @@ class StudyPact {
         guard let cryptohash = self.cryptoHash,
               let email = self.email,
               let url = EndpointKey.addClass.url,
-              let params = AddClassParams(email: email, cryptohash: cryptohash, prefs: preferences) else {
+              let params = AddClassParams(email: email, cryptohash: cryptohash, prefs: preferences)?.asJSON else {
             completion(false)
             return
         }
-        NetworkManager.shared.get(url: url, params: params, asType: AnyJSON.self) { response in
+        NetworkManager.shared.post(url: url, body: params, asType: AnyJSON.self) { response in
             switch response {
             case .success(_):
                 completion(true)

--- a/berkeley-mobile/StudyPact/StudyPact.swift
+++ b/berkeley-mobile/StudyPact/StudyPact.swift
@@ -20,138 +20,65 @@ class StudyPact {
         guard let cryptoHash = UserDefaults.standard.string(forKey: "userCryptoHash") else { return }
         // TODO: call AuthenticateUser. if authenticate fails but signed into google, call RegisterUser
     }
-    
+
     public func getBerkeleyCourses(completion: @escaping ([String]) -> Void) {
         guard let url = URL(string: "https://berkeleytime.com/api/catalog/catalog_json/") else {
             completion([])
             return
         }
-        getRequest(url: url) { data in
-            guard let data = data,
-                  let json = try JSONSerialization.jsonObject(with: data) as? Dictionary<String, AnyObject>,
-                  let courses = json["courses"] as? Array<Dictionary<String, AnyObject>> else {
-                completion([])
-                return
+        NetworkManager.shared.get(url: url, params: [:], asType: CoursesDocument.self) { response in
+            switch response {
+            case .success(let document):
+                guard let document = document else { break }
+                completion(document.courses.map { $0.abbreviation + " " + $0.number })
+            default:
+                break
             }
-            var classNames: [String] = []
-            for course in courses {
-                guard let courseNumber = course["course_number"] as? String,
-                      let abbreviation = course["abbreviation"] as? String else { continue }
-                classNames.append(abbreviation + " " + courseNumber)
-            }
-            completion(classNames)
+            completion([])
         }
     }
     
     public func registerUser(user: GIDGoogleUser?, completion: @escaping (Bool) -> Void) {
         guard let user = user,
               user.profile.email.hasSuffix("@berkeley.edu"),
-              let params = ["Email": user.profile.email, "FirstName": user.profile.givenName, "LastName": user.profile.familyName] as? Dictionary<String, String>,
-              let urlString = API_URLS["REGISTER_USER"],
+              let params = ["Email": user.profile.email, "FirstName": user.profile.givenName, "LastName": user.profile.familyName] as? [String: String],
+              let urlString = API_URLS[EndpointKey.registerUser.rawValue],
               let url = URL(string: urlString) else {
             completion(false)
             return
         }
-        postRequest(url: url, params: params) { data in
-            guard let data = data,
-                  let json = try JSONSerialization.jsonObject(with: data, options: []) as? Dictionary<String, AnyObject>,
-                  let cryptoHash = json["CryptoHash"] as? String else {
-                completion(false)
-                return
+        NetworkManager.shared.post(url: url, body: params) { response in
+            switch response {
+            case .success(let data):
+                guard let data = data, let cryptohash = data["CryptoHash"] as? String else { break }
+                self.cryptoHash = cryptohash
+                self.email = user.profile.email
+                self.saveCryptoHash(cryptoHash: cryptohash)
+                completion(true)
+            default:
+                break
             }
-            self.cryptoHash = cryptoHash
-            self.email = user.profile.email
-            self.saveCryptoHash(cryptoHash: cryptoHash)
-            completion(true)
+            completion(false)
         }
     }
     
     public func getGroups(completion: @escaping ([StudyGroup]) -> Void) {
         guard let cryptoHash = self.cryptoHash,
               let email = self.email,
-              let urlString = API_URLS["GET_GROUPS"],
+              let urlString = API_URLS[EndpointKey.getGroups.rawValue],
               let url = URL(string: urlString) else {
             completion([])
             return
         }
         let params = ["secret_token": cryptoHash, "user_email": email]
-        postRequest(url: url, params: params) { data in
-            guard let data = data,
-                  let json = try JSONSerialization.jsonObject(with: data, options: []) as? Array<Dictionary<String, AnyObject>> else {
+        NetworkManager.shared.post(url: url, body: params, asType: [StudyGroup].self) { response in
+            switch response {
+            case .success(let data):
+                completion(data ?? [])
+            default:
                 completion([])
-                return
             }
-            var groups: [StudyGroup] = []
-            for group in json {
-                guard let className = group["class_name"] as? String,
-                      let users = group["users"] as? Array<AnyObject>,
-                      let pending = group["pending"] as? Bool else {
-                    continue
-                }
-                var studyGroupMembers: [StudyGroupMember] = []
-                for user in users {
-                    guard let userDict = user as? Dictionary<String, String>,
-                          let name = userDict["name"],
-                          let email = userDict["email"] else {
-                        continue
-                    }
-                    let profileUrlString = userDict["profile_picture"]
-                    let member = StudyGroupMember(profilePictureURL: URL(string: profileUrlString ?? ""),
-                                                  name: name, email: email,
-                                                  phoneNumber: userDict["phone"],
-                                                  facebookUsername: userDict["facebook"])
-                    studyGroupMembers.append(member)
-                }
-                let group = StudyGroup(className: className, groupMembers: studyGroupMembers, pending: pending)
-                groups.append(group)
-            }
-            completion(groups)
         }
-    }
-    
-    private func postRequest(url: URL, params: Dictionary<String, String>, completion: @escaping (Data?) throws -> Void) {
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.httpBody = try? JSONSerialization.data(withJSONObject: params, options: [])
-        let session = URLSession.shared
-        let task = session.dataTask(with: request, completionHandler: { data, response, error -> Void in
-            guard let data = data, let response = response,
-                  let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200,
-                  error == nil else {
-                do {
-                    try completion(nil)
-                } catch {}
-                return
-            }
-            do {
-                try completion(data)
-            } catch {}
-            return
-        })
-        task.resume()
-    }
-    
-    private func getRequest(url: URL, completion: @escaping (Data?) throws -> Void) {
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        let session = URLSession.shared
-        let task = session.dataTask(with: request, completionHandler: { data, response, error -> Void in
-            guard let data = data, let response = response,
-                  let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200,
-                  error == nil else {
-                do {
-                    try completion(nil)
-                } catch {}
-                return
-            }
-            do {
-                try completion(data)
-            } catch {}
-            return
-        })
-        task.resume()
     }
     
     func getCryptoHash() -> String? {


### PR DESCRIPTION
Changes on top of #254 aimed to simplify JSON parsing. For `getGroups` and `getBerkeleyCourses` in `StudyPact.swift`, instead of reading response data as a `[String: Any]` dictionary and traversing the dictionary to construct objects, parse response data by defining expected structure and data types in structs conforming to `Decodable` in `StudyGroup.swift` and `Course.swift` located in the `StudyPact/API/Schema/` directory.

Other changes:
- Moves code for general `GET` and `POST` requests to `Data/Network/NetworkManager.swift`. The class has two public methods each for `GET` and `POST`, one which parses response data using a `Decodable`, and the other which parses response data into a `[String: Any]` dictionary, depending on user preference.