### PR TITLE
Implement Authenticate and Class Preference API

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		0181710525CA770A00BA6317 /* BTCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181710425CA770A00BA6317 /* BTCourse.swift */; };
 		0181710A25CA90D300BA6317 /* AuthenticateUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181710925CA90D300BA6317 /* AuthenticateUser.swift */; };
 		0181711125CAA3B300BA6317 /* AnyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181711025CAA3B300BA6317 /* AnyJSON.swift */; };
-		0181711725CAABB000BA6317 /* AddClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181711625CAABB000BA6317 /* AddClass.swift */; };
+		0181711725CAABB000BA6317 /* ClassPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181711625CAABB000BA6317 /* ClassPreference.swift */; };
 		0181711C25CB506A00BA6317 /* Encodable+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181711B25CB506A00BA6317 /* Encodable+JSON.swift */; };
 		018B982625327358004C3B26 /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982525327358004C3B26 /* ActionButton.swift */; };
 		018B982825328200004C3B26 /* Colors+ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B982725328200004C3B26 /* Colors+ActionButton.swift */; };
@@ -195,7 +195,7 @@
 		0181710425CA770A00BA6317 /* BTCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCourse.swift; sourceTree = "<group>"; };
 		0181710925CA90D300BA6317 /* AuthenticateUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticateUser.swift; sourceTree = "<group>"; };
 		0181711025CAA3B300BA6317 /* AnyJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyJSON.swift; sourceTree = "<group>"; };
-		0181711625CAABB000BA6317 /* AddClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddClass.swift; sourceTree = "<group>"; };
+		0181711625CAABB000BA6317 /* ClassPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassPreference.swift; sourceTree = "<group>"; };
 		0181711B25CB506A00BA6317 /* Encodable+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+JSON.swift"; sourceTree = "<group>"; };
 		018B982525327358004C3B26 /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
 		018B982725328200004C3B26 /* Colors+ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+ActionButton.swift"; sourceTree = "<group>"; };
@@ -403,7 +403,7 @@
 			children = (
 				0181710425CA770A00BA6317 /* BTCourse.swift */,
 				29DB64D125BA6269001C4275 /* StudyGroup.swift */,
-				0181711625CAABB000BA6317 /* AddClass.swift */,
+				0181711625CAABB000BA6317 /* ClassPreference.swift */,
 				0181710925CA90D300BA6317 /* AuthenticateUser.swift */,
 			);
 			path = Schema;
@@ -1286,7 +1286,7 @@
 				1336A320241D924300949F32 /* DiningItem.swift in Sources */,
 				299ACFB4244A5F90000F3E86 /* HasOccupancy.swift in Sources */,
 				0181710A25CA90D300BA6317 /* AuthenticateUser.swift in Sources */,
-				0181711725CAABB000BA6317 /* AddClass.swift in Sources */,
+				0181711725CAABB000BA6317 /* ClassPreference.swift in Sources */,
 				559A7B6D2373DEFA004EA501 /* MaterialTableViewCell.swift in Sources */,
 				29891B23257C521E0094891D /* PageViewController.swift in Sources */,
 				13EA64CD2399CEDA00FD8E13 /* Gym.swift in Sources */,

--- a/berkeley-mobile/Data/Network/NetworkManager.swift
+++ b/berkeley-mobile/Data/Network/NetworkManager.swift
@@ -112,6 +112,14 @@ class NetworkManager {
             completion(.failure(error: error))
         } else if let response = response as? HTTPURLResponse,
                   response.statusCode != 200 {
+            if let data = data {
+                do {
+                    let decoded = try decode(data)
+                    print("Recieved: \(response) with data: \(decoded)")
+                } catch {
+                    print("Recieved: \(response) with data: \(data)")
+                }
+            }
             completion(.failure(error: RequestError.badResponse(code: response.statusCode)))
         } else {
             guard let data = data else {

--- a/berkeley-mobile/StudyPact/API/Schema/ClassPreference.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/ClassPreference.swift
@@ -1,5 +1,5 @@
 //
-//  AddClass.swift
+//  ClassPreference.swift
 //  berkeley-mobile
 //
 //  Created by Kevin Hu on 2/3/21.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct AddClassParams: Encodable {
+struct AddPreferenceParams: Encodable {
     let email: String
     let cryptohash: String
     let className: String
@@ -31,5 +31,15 @@ struct AddClassParams: Encodable {
         self.className = className
         self.size = size
         self.env = isVirtual ? "virtual" : "in-person"
+    }
+}
+
+struct RemovePreferenceParams: Encodable {
+    let email: String
+    let cryptohash: String
+    let id: String
+
+    enum CodingKeys: String, CodingKey {
+        case email = "user_email", cryptohash = "secret_token", id = "class_id"
     }
 }

--- a/berkeley-mobile/StudyPact/API/Schema/StudyGroup.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/StudyGroup.swift
@@ -11,10 +11,12 @@ import UIKit
 struct StudyGroup: Decodable {
     let className: String
     let groupMembers: [StudyGroupMember]
+    let size: Int
     let pending: Bool
+    let id: String
 
     enum CodingKeys: String, CodingKey {
-        case className = "class_name", groupMembers = "users", pending
+        case className = "class_name", groupMembers = "users", pending, id, size
     }
 }
 

--- a/berkeley-mobile/StudyPact/CreatePreference/CreatePreferenceViewController.swift
+++ b/berkeley-mobile/StudyPact/CreatePreference/CreatePreferenceViewController.swift
@@ -119,11 +119,15 @@ class CreatePreferenceViewController: UIPageViewController, UIPageViewController
         moveToNextPage()
     }
     
-    @objc func savePreference(_: UIButton) {
+    @objc func savePreference(_ sender: UIButton) {
         // TODO: AddClass api call
-        print("send preference to backend")
-        print(preference)
-        self.dismiss(animated: true, completion: nil)
+        sender.isEnabled = false
+        StudyPact.shared.addClass(preferences: preference) { success in
+            sender.isEnabled = true
+            if success {
+                self.dismiss(animated: true, completion: nil)
+            }
+        }
     }
     
     public func setNextEnabled() {

--- a/berkeley-mobile/StudyPact/CreatePreference/CreatePreferenceViewController.swift
+++ b/berkeley-mobile/StudyPact/CreatePreference/CreatePreferenceViewController.swift
@@ -127,6 +127,8 @@ class CreatePreferenceViewController: UIPageViewController, UIPageViewController
             sender.alpha = 1.0
             if success {
                 self.dismiss(animated: true, completion: nil)
+            } else {
+                self.presentFailureAlert(title: "Unable to Save", message: "An issue occurred when attempting to save your group preference. Please try again later.")
             }
         }
     }

--- a/berkeley-mobile/StudyPact/CreatePreference/CreatePreferenceViewController.swift
+++ b/berkeley-mobile/StudyPact/CreatePreference/CreatePreferenceViewController.swift
@@ -120,10 +120,11 @@ class CreatePreferenceViewController: UIPageViewController, UIPageViewController
     }
     
     @objc func savePreference(_ sender: UIButton) {
-        // TODO: AddClass api call
         sender.isEnabled = false
+        sender.alpha = 0.5
         StudyPact.shared.addClass(preferences: preference) { success in
             sender.isEnabled = true
+            sender.alpha = 1.0
             if success {
                 self.dismiss(animated: true, completion: nil)
             }

--- a/berkeley-mobile/StudyPact/SignInManager.swift
+++ b/berkeley-mobile/StudyPact/SignInManager.swift
@@ -31,9 +31,11 @@ class SignInManager: NSObject, GIDSignInDelegate {
         GIDSignIn.sharedInstance()?.delegate = self
         if let previous = GIDSignIn.sharedInstance()?.hasPreviousSignIn(), previous {
             GIDSignIn.sharedInstance()?.restorePreviousSignIn()
-            if !StudyPact.shared.loadCryptoHash() {
-                GIDSignIn.sharedInstance()?.signOut()
-                StudyPact.shared.reset()
+            StudyPact.shared.loadCryptoHash { success in
+                if !success {
+                    GIDSignIn.sharedInstance()?.signOut()
+                    StudyPact.shared.reset()
+                }
             }
         } else {
             StudyPact.shared.reset()

--- a/berkeley-mobile/StudyPact/StudyGroups/PendingGroupViewController.swift
+++ b/berkeley-mobile/StudyPact/StudyGroups/PendingGroupViewController.swift
@@ -98,16 +98,11 @@ class PendingGroupViewController: UIViewController {
                 if success {
                     self.dismiss(animated: true, completion: nil)
                 } else {
-                    self.alertError()
+                    self.presentFailureAlert(title: "Unable to Remove", message: "An issue occurred when attempting to remove your pending request. Please try again later.")
                 }
             }
         }))
         self.present(alertController, animated: true, completion: nil)
-    }
-
-    private func alertError() {
-        let alertController = UIAlertController(title: "Unable to Remove", message: "An issue occurred when attempting to remove your pending request. Please try again later.", preferredStyle: .alert)
-        alertController.addAction(UIAlertAction.init(title: "Cancel", style: .cancel))
     }
     
     public func presentSelf(presentingVC: UIViewController, studyGroup: StudyGroup) {

--- a/berkeley-mobile/StudyPact/StudyGroups/PendingGroupViewController.swift
+++ b/berkeley-mobile/StudyPact/StudyGroups/PendingGroupViewController.swift
@@ -94,9 +94,11 @@ class PendingGroupViewController: UIViewController {
         let alertController = UIAlertController(title: "Remove Pending Request", message: "Would you like to remove your pending request to join a study group for \(studyGroup.className)?", preferredStyle: .alert)
         alertController.addAction(UIAlertAction.init(title: "Cancel", style: .cancel))
         alertController.addAction(UIAlertAction.init(title: "Yes", style: .default, handler: { _ in
-            print("remove request")
-            // TODO: call CancelPending
-            self.dismiss(animated: true, completion: nil)
+            StudyPact.shared.cancelPending(group: self.studyGroup) { success in
+                if success {
+                    self.dismiss(animated: true, completion: nil)
+                }
+            }
         }))
         self.present(alertController, animated: true, completion: nil)
     }

--- a/berkeley-mobile/StudyPact/StudyGroups/PendingGroupViewController.swift
+++ b/berkeley-mobile/StudyPact/StudyGroups/PendingGroupViewController.swift
@@ -97,10 +97,17 @@ class PendingGroupViewController: UIViewController {
             StudyPact.shared.cancelPending(group: self.studyGroup) { success in
                 if success {
                     self.dismiss(animated: true, completion: nil)
+                } else {
+                    self.alertError()
                 }
             }
         }))
         self.present(alertController, animated: true, completion: nil)
+    }
+
+    private func alertError() {
+        let alertController = UIAlertController(title: "Unable to Remove", message: "An issue occurred when attempting to remove your pending request. Please try again later.", preferredStyle: .alert)
+        alertController.addAction(UIAlertAction.init(title: "Cancel", style: .cancel))
     }
     
     public func presentSelf(presentingVC: UIViewController, studyGroup: StudyGroup) {

--- a/berkeley-mobile/StudyPact/StudyPact.swift
+++ b/berkeley-mobile/StudyPact/StudyPact.swift
@@ -20,13 +20,14 @@ class StudyPact {
     var email: String?
 
     /// Load cryptohash from user defaults. If it doesnt exist or authenticate fails, return false.
-    public func loadCryptoHash() -> Bool {
-        if let cryptoHash = UserDefaults.standard.string(forKey: "userCryptoHash") {
+    public func loadCryptoHash(completion: @escaping (Bool) -> Void) {
+        print(UserDefaults.standard.string(forKey: kCryptoHashKey))
+        if let cryptoHash = UserDefaults.standard.string(forKey: kCryptoHashKey) {
             self.cryptoHash = cryptoHash
-            // TODO: authenticate user first. if authenticate fails return false
-            return true
+            authenticateUser(completion: completion)
+        } else {
+            completion(false)
         }
-        return false
     }
     
     /// Reset all properties. Should be called if user is signed out of google

--- a/berkeley-mobile/StudyPact/StudyPact.swift
+++ b/berkeley-mobile/StudyPact/StudyPact.swift
@@ -9,13 +9,16 @@
 import Foundation
 import GoogleSignIn
 
-/// All StudyPact api call functions go in here. Relevant user info also goes here.
+fileprivate let kCryptoHashKey = "userCryptoHash"
+
+/// All StudyPact API call functions go in here. Relevant user info also goes here.
 class StudyPact {
+
     static let shared = StudyPact()
     
     private var cryptoHash: String?
     var email: String?
-    
+
     /// Load cryptohash from user defaults. If it doesnt exist or authenticate fails, return false.
     public func loadCryptoHash() -> Bool {
         if let cryptoHash = UserDefaults.standard.string(forKey: "userCryptoHash") {
@@ -32,6 +35,23 @@ class StudyPact {
         self.cryptoHash = nil
         self.email = nil
     }
+
+    func getCryptoHash() -> String? {
+        return cryptoHash
+    }
+
+    private func saveCryptoHash(cryptoHash: String) {
+        UserDefaults.standard.set(cryptoHash, forKey: kCryptoHashKey)
+    }
+
+    private func deleteCryptoHash() {
+        UserDefaults.standard.removeObject(forKey: kCryptoHashKey)
+    }
+}
+
+// MARK: - API
+
+extension StudyPact {
 
     // MARK: GetBerkeleyCourses
 
@@ -95,13 +115,17 @@ class StudyPact {
         }
     }
 
+    // MARK: GetUser
+
+    // MARK: AddUser
+
     // MARK: AddClass
 
     public func addClass(preferences: StudyPactPreference, completion: @escaping(Bool) -> Void) {
         guard let cryptohash = self.cryptoHash,
               let email = self.email,
               let url = EndpointKey.addClass.url,
-              let params = AddClassParams(email: email, cryptohash: cryptohash, prefs: preferences)?.asJSON else {
+              let params = AddPreferenceParams(email: email, cryptohash: cryptohash, prefs: preferences)?.asJSON else {
             completion(false)
             return
         }
@@ -114,6 +138,28 @@ class StudyPact {
             }
         }
     }
+
+    // MARK: CancelPending
+
+    public func cancelPending(group: StudyGroup, completion: @escaping(Bool) -> Void) {
+        guard let cryptohash = self.cryptoHash,
+              let email = self.email,
+              let url = EndpointKey.cancelPending.url,
+              let params = RemovePreferenceParams(email: email, cryptohash: cryptohash, id: group.id).asJSON else {
+            completion(false)
+            return
+        }
+        NetworkManager.shared.post(url: url, body: params, asType: AnyJSON.self) { response in
+            switch response {
+            case .success(_):
+                completion(true)
+            default:
+                completion(false)
+            }
+        }
+    }
+
+    // MARK: LeaveGroup
 
     // MARK: GetGroups
     
@@ -133,17 +179,5 @@ class StudyPact {
                 completion([])
             }
         }
-    }
-    
-    func getCryptoHash() -> String? {
-        return cryptoHash
-    }
-    
-    private func saveCryptoHash(cryptoHash: String) {
-        UserDefaults.standard.set(cryptoHash, forKey: "userCryptoHash")
-    }
-    
-    private func deleteCryptoHash() {
-        UserDefaults.standard.removeObject(forKey: "userCryptoHash")
     }
 }

--- a/berkeley-mobile/StudyPact/StudyPact.swift
+++ b/berkeley-mobile/StudyPact/StudyPact.swift
@@ -21,7 +21,6 @@ class StudyPact {
 
     /// Load cryptohash from user defaults. If it doesnt exist or authenticate fails, return false.
     public func loadCryptoHash(completion: @escaping (Bool) -> Void) {
-        print(UserDefaults.standard.string(forKey: kCryptoHashKey))
         if let cryptoHash = UserDefaults.standard.string(forKey: kCryptoHashKey) {
             self.cryptoHash = cryptoHash
             authenticateUser(completion: completion)


### PR DESCRIPTION
Add call to `StudyPact.authenticate` during `StudyPact.loadCryptoHash`. Add `.cancelPending` and hook up `.addClass` and `.cancelPending` to their locations in the UI.
- Add failure alerts when adding / removing pending class preferences fails.
- Rename `StudyPact/API/Schema/AddClass.swift` > `ClassPreference.swift`
  - Rename `AddClassParams` > `AddPreferenceParams`
  - Add `RemovePreferenceParams`
- Add `size` and `id` properties to `StudyGroup`
- Add print statements on network request failure to aid in future debugging.