### PR TITLE
Leave Group and Add Class changes

### DIFF
--- a/berkeley-mobile/StudyPact/API/Schema/ClassPreference.swift
+++ b/berkeley-mobile/StudyPact/API/Schema/ClassPreference.swift
@@ -22,14 +22,15 @@ struct AddPreferenceParams: Encodable {
 
     init?(email: String, cryptohash: String, prefs: StudyPactPreference) {
         guard let className = prefs.className,
-              let size = prefs.numberOfPeople,
+              let numberOfPeople = prefs.numberOfPeople,
               let isVirtual = prefs.isVirtual else {
             return nil
         }
         self.email = email
         self.cryptohash = cryptohash
         self.className = className
-        self.size = size
+        // backend wants us to send the preferred total people (including self)
+        self.size = numberOfPeople + 1
         self.env = isVirtual ? "virtual" : "in-person"
     }
 }

--- a/berkeley-mobile/StudyPact/StudyGroups/StudyGroupDetailsViewController.swift
+++ b/berkeley-mobile/StudyPact/StudyGroups/StudyGroupDetailsViewController.swift
@@ -20,13 +20,18 @@ class StudyGroupDetailsViewController: UIViewController {
     }
     
     @objc func leaveGroup() {
-        StudyPact.shared.leaveGroup(group: _studyGroup) { success in
-            if success {
-                self.presentSuccessAlert(title: "Successfully left group")
-            } else {
-                self.presentFailureAlert(title: "Failed to leave group", message: "There was an error. Please try again later.")
+        let alertController = UIAlertController(title: "Leave Study Group", message: "Would you like to leave your study group for \(_studyGroup.className)?", preferredStyle: .alert)
+        alertController.addAction(UIAlertAction.init(title: "Cancel", style: .cancel))
+        alertController.addAction(UIAlertAction.init(title: "Yes", style: .default, handler: { _ in
+            StudyPact.shared.leaveGroup(group: self._studyGroup) { success in
+                if success {
+                    self.dismiss(animated: true, completion: nil)
+                } else {
+                    self.presentFailureAlert(title: "Failed to Leave Group", message: "There was an error. Please try again later.")
+                }
             }
-        }
+        }))
+        self.present(alertController, animated: true, completion: nil)
     }
     
     let card: CardView = {

--- a/berkeley-mobile/StudyPact/StudyPact.swift
+++ b/berkeley-mobile/StudyPact/StudyPact.swift
@@ -218,8 +218,6 @@ extension StudyPact {
         }
     }
 
-    // MARK: LeaveGroup
-
     // MARK: GetGroups
     
     public func getGroups(completion: @escaping ([StudyGroup]) -> Void) {
@@ -241,8 +239,7 @@ extension StudyPact {
         }
     }
     
-    /// MARK: LeaveGroup
-    // backend hasn't implemented this yet, may need to modify
+    // MARK: LeaveGroup
     public func leaveGroup(group: StudyGroup, completion: @escaping (Bool) -> Void) {
         guard let cryptoHash = self.cryptoHash,
               let email = self.email,


### PR DESCRIPTION
Leave group now shows a popup to confirm and dismisses on success. The backend works as well.
Add class has been changed to send preferred number of people to study with + 1 because backend wants the total size of the group (including self).