### PR TITLE
NetworkManager Failure Response Decoding

### DIFF
--- a/berkeley-mobile/Data/Network/NetworkManager.swift
+++ b/berkeley-mobile/Data/Network/NetworkManager.swift
@@ -160,7 +160,13 @@ class NetworkManager {
                     let decoded = try decode(data)
                     print("Recieved: \(response) with data: \(decoded)")
                 } catch {
-                    print("Recieved: \(response) with data: \(data)")
+                    do {
+                        // Try to decode as `AnyJSON`
+                        let decoded = try JSONDecoder().decode(AnyJSON.self, from: data)
+                        print("Recieved: \(response) with data: \(decoded)")
+                    } catch {
+                        print("Recieved: \(response) with data: \(data)")
+                    }
                 }
             }
             completion(.failure(error: RequestError.badResponse(code: response.statusCode)))


### PR DESCRIPTION
Previously, when handling a non-okay status code in `NetworkManager`, the data is printed for debug purposes. If the data cannot be decoded as the given expected type, no more attempts to decode the data are made. Change this to decode the data as `AnyJSON` (e.g. String) if the first decode attempt fails.

### Before
<img width="643" alt="Screen Shot 2021-02-14 at 5 17 50 PM" src="https://user-images.githubusercontent.com/41145903/107896292-ae439780-6eea-11eb-8a57-e2b5a9a1fd49.png">

### After
<img width="644" alt="Screen Shot 2021-02-14 at 5 27 31 PM" src="https://user-images.githubusercontent.com/41145903/107896297-b1d71e80-6eea-11eb-8f52-f158abc3b357.png">
