### PR TITLE
Property Wrapper for Display Strings

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		016A56D42519E96800531A12 /* CampusCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A56D32519E96800531A12 /* CampusCalendarViewController.swift */; };
 		016A56D6251AD38F00531A12 /* CalendarEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A56D5251AD38F00531A12 /* CalendarEvent.swift */; };
 		016A56D8251C930D00531A12 /* AppDelegate+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A56D7251C930D00531A12 /* AppDelegate+Migration.swift */; };
+		0176B60F25FD933D004D379C /* Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0176B60E25FD933D004D379C /* Display.swift */; };
 		017C0B26251018BA00BFA80A /* Colors+MapMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */; };
 		0181710525CA770A00BA6317 /* BTCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181710425CA770A00BA6317 /* BTCourse.swift */; };
 		0181710A25CA90D300BA6317 /* AuthenticateUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0181710925CA90D300BA6317 /* AuthenticateUser.swift */; };
@@ -197,6 +198,7 @@
 		016A56D32519E96800531A12 /* CampusCalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampusCalendarViewController.swift; sourceTree = "<group>"; };
 		016A56D5251AD38F00531A12 /* CalendarEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEvent.swift; sourceTree = "<group>"; };
 		016A56D7251C930D00531A12 /* AppDelegate+Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Migration.swift"; sourceTree = "<group>"; };
+		0176B60E25FD933D004D379C /* Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Display.swift; sourceTree = "<group>"; };
 		017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+MapMarker.swift"; sourceTree = "<group>"; };
 		0181710425CA770A00BA6317 /* BTCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTCourse.swift; sourceTree = "<group>"; };
 		0181710925CA90D300BA6317 /* AuthenticateUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticateUser.swift; sourceTree = "<group>"; };
@@ -399,6 +401,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0176B61125FD9347004D379C /* PropertyWrappers */ = {
+			isa = PBXGroup;
+			children = (
+				0176B60E25FD933D004D379C /* Display.swift */,
+			);
+			path = PropertyWrappers;
+			sourceTree = "<group>";
+		};
 		01CDBBE625CA6ADD006B93BD /* API */ = {
 			isa = PBXGroup;
 			children = (
@@ -663,6 +673,7 @@
 				01CDBBEB25CA6F3D006B93BD /* Network */,
 				299ACFAE244A58A8000F3E86 /* Occupancy */,
 				13B8E95724256E4F00E7FCBF /* ItemProtocols */,
+				0176B61125FD9347004D379C /* PropertyWrappers */,
 				13EA64CF2399D50C00FD8E13 /* DataManager.swift */,
 				13B39A8C23E689BC0039FBA2 /* DataSource.swift */,
 				01FA50F024E8B33100DCC490 /* LocationManager.swift */,
@@ -1287,6 +1298,7 @@
 				FD6FB45C25C62EB90045A03A /* SelectEnvironmentView.swift in Sources */,
 				29F09C3525D76EDF003FB69F /* StudyPactNewFeatureViewController.swift in Sources */,
 				01CDBBC725CA3B13006B93BD /* NetworkManager.swift in Sources */,
+				0176B60F25FD933D004D379C /* Display.swift in Sources */,
 				018B982825328200004C3B26 /* Colors+ActionButton.swift in Sources */,
 				296B8AA72544D97F00C3A219 /* EventOverviewCardView.swift in Sources */,
 				29387E9B24BBBD9D00070BCE /* CALayerExtension.swift in Sources */,

--- a/berkeley-mobile/Calendar/EventDataSource/EventCalendarEntry.swift
+++ b/berkeley-mobile/Calendar/EventDataSource/EventCalendarEntry.swift
@@ -11,11 +11,11 @@ import UIKit
 
 class EventCalendarEntry: CalendarEvent, HasImage, CanFavorite {
     // MARK: CalendarEvent Fields
-    var name: String
+    @Display var name: String
     var date: Date
     var end: Date?
-    var description: String?
-    var location: String?
+    @Display var description: String?
+    @Display var location: String?
     
     var additionalDescription: String {
         get {

--- a/berkeley-mobile/Data/PropertyWrappers/Display.swift
+++ b/berkeley-mobile/Data/PropertyWrappers/Display.swift
@@ -1,0 +1,41 @@
+//
+//  Display.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 3/13/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+/// Wrapper for strings intended to be displayed. Removes excess whitespace and invalid characters.
+/// Type `T` must be `String` or `String?`.
+@propertyWrapper struct Display<T> {
+
+    private var _display: T
+
+    var wrappedValue: T {
+        get { return _display }
+        set { _display = Display.wrap(newValue) }
+    }
+
+    init(wrappedValue: T) where T == String { _display = Display.wrap(wrappedValue) }
+    init(wrappedValue: T) where T == String? { _display = Display.wrap(wrappedValue) }
+
+    private static func wrap(_ rawString: String) -> String {
+        return rawString
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "�", with: "")
+    }
+
+    private static func wrap(_ rawValue: String?) -> String? {
+        guard let rawString = rawValue else { return rawValue }
+        return Display.wrap(rawString)
+    }
+
+    private static func wrap(_ rawValue: T) -> T {
+        guard let rawString = rawValue as? String else { return rawValue }
+        guard let wrappedValue = Display.wrap(rawString) as? T else { return rawValue }
+        return wrappedValue
+    }
+}

--- a/berkeley-mobile/Dining/DiningDataSource/DiningItem.swift
+++ b/berkeley-mobile/Dining/DiningDataSource/DiningItem.swift
@@ -14,7 +14,7 @@ typealias DiningMenu = Array<DiningItem>
 /** Object representing a single dish/item. */
 class DiningItem: HasName {
     
-    let name: String
+    @Display var name: String
     var isFavorited: Bool = false
     
     // Additional information regarding food such as allergens or alternative options

--- a/berkeley-mobile/Dining/DiningDataSource/DiningLocation.swift
+++ b/berkeley-mobile/Dining/DiningDataSource/DiningLocation.swift
@@ -17,10 +17,10 @@ class DiningLocation: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasI
         return name
     }
     
-    let name: String
+    @Display var name: String
     let imageURL: URL?
-    let address: String?
-    let phoneNumber: String?
+    @Display var address: String?
+    @Display var phoneNumber: String?
     
     var meals: MealMap
     var weeklyHours: WeeklyHours?

--- a/berkeley-mobile/Fitness/GymClassDataSource/GymClass.swift
+++ b/berkeley-mobile/Fitness/GymClassDataSource/GymClass.swift
@@ -13,11 +13,11 @@ class GymClass: CalendarEvent {
 
     // MARK: CalendarEvent Fields
 
-    var name: String
+    @Display var name: String
     var date: Date
     var end: Date?
-    var description: String?
-    var location: String?
+    @Display var description: String?
+    @Display var location: String?
     
     var additionalDescription: String {
         get {

--- a/berkeley-mobile/Fitness/GymClassDataSource/GymClass.swift
+++ b/berkeley-mobile/Fitness/GymClassDataSource/GymClass.swift
@@ -37,7 +37,7 @@ class GymClass: CalendarEvent {
     var link: String?
 
     /// The trainer leading this gym class.
-    var trainer: String?
+    @Display var trainer: String?
 
     /// The category for this class. See `GymClassType` for expected values.
     var type: String?

--- a/berkeley-mobile/Fitness/GymDataSource/Gym.swift
+++ b/berkeley-mobile/Fitness/GymDataSource/Gym.swift
@@ -58,7 +58,7 @@ class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOp
 
     init(name: String, description: String?, address: String?, phoneNumber: String?, imageLink: String?, weeklyHours: WeeklyHours?, link: String?) {
         self.address = address?.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.description = description?.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "�", with: "")
+        self.description = description
         self.phoneNumber = phoneNumber
         self.weeklyHours = weeklyHours
         self.name = name.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/berkeley-mobile/Fitness/GymDataSource/Gym.swift
+++ b/berkeley-mobile/Fitness/GymDataSource/Gym.swift
@@ -23,7 +23,7 @@ class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOp
 
     var latitude: Double?
     var longitude: Double?
-    let address: String?
+    @Display var address: String?
 
     // MARK: HasImage
     
@@ -31,7 +31,7 @@ class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOp
 
     // MARK: HasPhoneNumber
 
-    let phoneNumber: String?
+    @Display var phoneNumber: String?
 
     // MARK: HasOpenTimes
 
@@ -48,13 +48,13 @@ class Gym: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, HasOp
     // MARK: Additional Properties
 
     /// The display-friendly name of this Gym.
-    let name: String
+    @Display var name: String
 
     /// An optional URL linking to a website for this Fitness location.
     var website: URL?
 
     /// A display-friendly string description of this Fitness location.
-    let description: String?
+    @Display var description: String?
 
     init(name: String, description: String?, address: String?, phoneNumber: String?, imageLink: String?, weeklyHours: WeeklyHours?, link: String?) {
         self.address = address?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/berkeley-mobile/Libraries/LibraryDataSource/Library.swift
+++ b/berkeley-mobile/Libraries/LibraryDataSource/Library.swift
@@ -28,14 +28,14 @@ class Library: SearchItem, HasLocation, CanFavorite, HasPhoneNumber, HasImage, H
         return "Librar" + (pluralized ? "ies" : "y")
     }
     
-    let name: String
+    @Display var name: String
     let imageURL: URL?
     
     var isFavorited: Bool = false
 
-    var description: String?
-    let address: String?
-    let phoneNumber: String?
+    @Display var description: String?
+    @Display var address: String?
+    @Display var phoneNumber: String?
     let weeklyHours: WeeklyHours?
     var occupancy: Occupancy?
     var weeklyByAppointment:[Bool]

--- a/berkeley-mobile/Map/MapDataSource/MapMarker.swift
+++ b/berkeley-mobile/Map/MapDataSource/MapMarker.swift
@@ -169,12 +169,12 @@ class MapMarker: NSObject, MKAnnotation, HasOpenTimes {
     var type: KnownType<MapMarkerType>
     
     var coordinate: CLLocationCoordinate2D
-    var title: String?
-    var subtitle: String?
+    @Display var title: String?
+    @Display var subtitle: String?
     
-    var phone: String?
-    var email: String?
-    var address: String?
+    @Display var phone: String?
+    @Display var email: String?
+    @Display var address: String?
     var onCampus: Bool?
 
     var weeklyHours: WeeklyHours?

--- a/berkeley-mobile/Resources/Covid/CovidResource.swift
+++ b/berkeley-mobile/Resources/Covid/CovidResource.swift
@@ -12,10 +12,10 @@ import Foundation
 class CovidResource {
 
     let dailyScreeningLink: String
-    let lastUpdated: String
-    let positivityRate: String
-    let totalCases: String
-    let dailyIncrease: String
+    @Display var lastUpdated: String
+    @Display var positivityRate: String
+    @Display var totalCases: String
+    @Display var dailyIncrease: String
 
     init(dailyScreeningLink: String, lastUpdated: Double, positivityRate: String, totalCases: String, dailyIncrease: String) {
         self.dailyScreeningLink = dailyScreeningLink

--- a/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
+++ b/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
@@ -27,9 +27,9 @@ class Resource: SearchItem, HasLocation, HasOpenTimes {
     var latitude: Double?
     var longitude: Double?
     
-    let name: String
-    let address: String?
-    let description: String?
+    @Display var name: String
+    @Display<String?> var address: String?
+    @Display<String?> var description: String?
     var weeklyHours: WeeklyHours?
 
     /// The category for this resource. See `ResourceType` for expected values.
@@ -43,6 +43,7 @@ class Resource: SearchItem, HasLocation, HasOpenTimes {
     init(name: String, address: String?, latitude: Double?, longitude: Double?, description: String?, hours: WeeklyHours?, type: String?) {
         self.name = name
         self.address = address
+        self.address = "test"
         self.latitude = latitude
         self.longitude = longitude
         self.description = description

--- a/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
+++ b/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
@@ -28,8 +28,8 @@ class Resource: SearchItem, HasLocation, HasOpenTimes {
     var longitude: Double?
     
     @Display var name: String
-    @Display<String?> var address: String?
-    @Display<String?> var description: String?
+    @Display var address: String?
+    @Display var description: String?
     var weeklyHours: WeeklyHours?
 
     /// The category for this resource. See `ResourceType` for expected values.

--- a/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
+++ b/berkeley-mobile/Resources/ResourcesDataSource/Resource.swift
@@ -43,7 +43,6 @@ class Resource: SearchItem, HasLocation, HasOpenTimes {
     init(name: String, address: String?, latitude: Double?, longitude: Double?, description: String?, hours: WeeklyHours?, type: String?) {
         self.name = name
         self.address = address
-        self.address = "test"
         self.latitude = latitude
         self.longitude = longitude
         self.description = description


### PR DESCRIPTION
Cleans up invalid characters or extra whitespace in some display strings pulled from Firebase.
- Adds `Display` property wrapper
  - Trims whitespace, removes `�` character
- Wraps important fields for Libraries, Gyms, Dining, Campus Resources, Events, etc.
  - `name`, `address` / `location`, `description`, `email`, `phone`, ...