### PR TITLE
Show Mental Health Resources under Health Tab

### DIFF
--- a/berkeley-mobile/Assets/Colors/Colors+Resource.swift
+++ b/berkeley-mobile/Assets/Colors/Colors+Resource.swift
@@ -17,6 +17,10 @@ extension Color {
             UIColor(displayP3Red: 225/255, green: 77/255, blue: 77/255, alpha: 0.89)
         }
 
+        static var mentalHealth: UIColor {
+            return UIColor(displayP3Red: 249/255, green: 180/255, blue: 35/255, alpha: 1.0)
+        }
+
         static var finances: UIColor {
             UIColor(displayP3Red: 92/255, green: 198/255, blue: 175/255, alpha: 0.89)
         }

--- a/berkeley-mobile/Resources/Campus/CampusResourceViewController.swift
+++ b/berkeley-mobile/Resources/Campus/CampusResourceViewController.swift
@@ -26,20 +26,21 @@ class CampusResourceViewController: UIViewController {
     /// If not empty, this view will present the filtered set of campus resources.
     private var resourceFilters: [Filter<Resource>] = []
 
-    convenience init() {
-        self.init(type: nil, notIn: nil)
+    convenience init(type: ResourceType, notIn: Set<ResourceType>? = nil) {
+        self.init(inSet: Set<ResourceType>([type]), notIn: notIn)
     }
 
-    /// If `type` is non-nil, will filter resources for those matching that `ResourceType`.
-    /// If `types` is non-nil, will filter resources for those not in the given set of types.
-    init(type: ResourceType?, notIn types: Set<ResourceType>? = nil) {
+    /// If `inSet` is non-nil, will filter resources for those matching those `ResourceType`s.
+    /// If `notIn` is non-nil, will filter resources for those not in the given set of types.
+    init(inSet: Set<ResourceType>? = nil, notIn: Set<ResourceType>? = nil) {
         super.init(nibName: nil, bundle: nil)
-        if let type = type {
-            resourceFilters.append(Filter(label: "Type Filter: \(type)", filter: { resource in
-                return resource.type == type.rawValue
+        if let types = inSet {
+            resourceFilters.append(Filter(label: "Type Filter: \(types)", filter: { resource in
+                guard let resourceType = ResourceType(rawValue: resource.type ?? "") else { return false }
+                return types.contains(resourceType)
             }))
         }
-        if let types = types {
+        if let types = notIn {
             resourceFilters.append(Filter(label: "Set Exclusion: \(types)", filter: { resource in
                 guard let resourceType = ResourceType(rawValue: resource.type ?? "") else { return true }
                 return !types.contains(resourceType)

--- a/berkeley-mobile/Resources/ResourcesDataSource/ResourceType.swift
+++ b/berkeley-mobile/Resources/ResourcesDataSource/ResourceType.swift
@@ -12,6 +12,7 @@ import UIKit
 enum ResourceType: String {
 
     case health = "Health"
+    case mentalHealth = "Mental Health"
     case basicNeeds = "Basic Needs"
     case admin = "Admin"
 
@@ -19,6 +20,8 @@ enum ResourceType: String {
         switch self {
         case .health:
             return Color.Resource.health
+        case .mentalHealth:
+            return Color.Resource.mentalHealth
         case .basicNeeds:
             return Color.Resource.basicNeeds
         case .admin:

--- a/berkeley-mobile/Resources/ResourcesViewController.swift
+++ b/berkeley-mobile/Resources/ResourcesViewController.swift
@@ -64,12 +64,13 @@ extension ResourcesViewController {
         // Don't add this padding for now.
         let segmentedControl = SegmentedControlViewController(pages: [
             Page(viewController: CovidResourceViewController(), label: "Dashboard"),
-            Page(viewController: CampusResourceViewController(type: .health), label: "Health"),
+            Page(viewController: CampusResourceViewController(
+                inSet: Set<ResourceType>([.health, .mentalHealth])
+            ), label: "Health"),
             Page(viewController: CampusResourceViewController(type: .admin), label: "Admin"),
             Page(viewController: CampusResourceViewController(type: .basicNeeds), label: "Basic Needs"),
             Page(viewController: CampusResourceViewController(
-                type: nil,
-                notIn: Set<ResourceType>([.health, .admin, .basicNeeds])
+                notIn: Set<ResourceType>([.health, .mentalHealth, .admin, .basicNeeds])
             ), label: "Other")
         ], controlInsets: UIEdgeInsets(top: 0, left: view.layoutMargins.left,
                                        bottom: 0, right: blobImageView.frame.width / 4),


### PR DESCRIPTION
Adds `"Mental Health"` to the list of known resource types / colors, set up the `"Health"` tab to contain both health and mental health resources.