### PR TITLE
Hide compass when search results are up

### DIFF
--- a/berkeley-mobile/Map/MapViewController.swift
+++ b/berkeley-mobile/Map/MapViewController.swift
@@ -205,12 +205,14 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
             self.searchResultsView.isHidden = false
             mainContainer?.hideTop()
             self.userLocationButton.isHidden = true
+            self.compass?.isHidden = true
         } else {
             self.maskView.isHidden = true
             self.searchResultsView.isHidden = true
             self.searchResultsView.isScrolling = false
             mainContainer?.showTop()
             self.userLocationButton?.isHidden = false
+            self.compass?.isHidden = false
         }
     }
     


### PR DESCRIPTION
Previously, the map's compass (shown when the map is rotated from the default north-facing orientation) is shown on top of the search results. Changes the view to hide the compass when the view is up.