### PR TITLE
[Do not merge] Sample Form and Input Fields

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -45,6 +45,15 @@
 		01D2699A2544D86C000377B4 /* Apercu Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D269912544D86C000377B4 /* Apercu Medium.otf */; };
 		01D2699B2544D86C000377B4 /* Apercu Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D269922544D86C000377B4 /* Apercu Regular.otf */; };
 		01D2699D2544E005000377B4 /* AcademicCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2699C2544E005000377B4 /* AcademicCalendarViewController.swift */; };
+		01E86277270E777A0085209A /* TagInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E86270270E777A0085209A /* TagInputView.swift */; };
+		01E86278270E777A0085209A /* NumberInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E86271270E777A0085209A /* NumberInputView.swift */; };
+		01E86279270E777A0085209A /* LabeledInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E86272270E777A0085209A /* LabeledInputView.swift */; };
+		01E8627A270E777A0085209A /* SliderInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E86273270E777A0085209A /* SliderInputView.swift */; };
+		01E8627B270E777A0085209A /* TextBoxInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E86274270E777A0085209A /* TextBoxInputView.swift */; };
+		01E8627C270E777A0085209A /* TextFieldInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E86275270E777A0085209A /* TextFieldInputView.swift */; };
+		01E8627D270E777A0085209A /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E86276270E777A0085209A /* InputView.swift */; };
+		01E86280270E77970085209A /* SampleFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E8627F270E77970085209A /* SampleFormViewController.swift */; };
+		01E86286270E78920085209A /* Colors+InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E86285270E78920085209A /* Colors+InputView.swift */; };
 		01FA50F124E8B33100DCC490 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA50F024E8B33100DCC490 /* LocationManager.swift */; };
 		01FA50F324E8BA5400DCC490 /* LocationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA50F224E8BA5400DCC490 /* LocationDetailView.swift */; };
 		0B07A47A14FC87CF20DD4870 /* Pods_berkeley_mobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9CAC9CEE1078D95B189B835 /* Pods_berkeley_mobile.framework */; };
@@ -241,6 +250,15 @@
 		01D269912544D86C000377B4 /* Apercu Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Apercu Medium.otf"; sourceTree = "<group>"; };
 		01D269922544D86C000377B4 /* Apercu Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Apercu Regular.otf"; sourceTree = "<group>"; };
 		01D2699C2544E005000377B4 /* AcademicCalendarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AcademicCalendarViewController.swift; sourceTree = "<group>"; };
+		01E86270270E777A0085209A /* TagInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TagInputView.swift; sourceTree = "<group>"; };
+		01E86271270E777A0085209A /* NumberInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberInputView.swift; sourceTree = "<group>"; };
+		01E86272270E777A0085209A /* LabeledInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabeledInputView.swift; sourceTree = "<group>"; };
+		01E86273270E777A0085209A /* SliderInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SliderInputView.swift; sourceTree = "<group>"; };
+		01E86274270E777A0085209A /* TextBoxInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextBoxInputView.swift; sourceTree = "<group>"; };
+		01E86275270E777A0085209A /* TextFieldInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldInputView.swift; sourceTree = "<group>"; };
+		01E86276270E777A0085209A /* InputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputView.swift; sourceTree = "<group>"; };
+		01E8627F270E77970085209A /* SampleFormViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleFormViewController.swift; sourceTree = "<group>"; };
+		01E86285270E78920085209A /* Colors+InputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+InputView.swift"; sourceTree = "<group>"; };
 		01FA50F024E8B33100DCC490 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		01FA50F224E8BA5400DCC490 /* LocationDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDetailView.swift; sourceTree = "<group>"; };
 		130FA59D243B1243005DC752 /* DiningRestriction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiningRestriction.swift; sourceTree = "<group>"; };
@@ -457,6 +475,29 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		01E8626E270E777A0085209A /* InputView */ = {
+			isa = PBXGroup;
+			children = (
+				01E8627F270E77970085209A /* SampleFormViewController.swift */,
+				01E86276270E777A0085209A /* InputView.swift */,
+				01E8626F270E777A0085209A /* InputViews */,
+			);
+			path = InputView;
+			sourceTree = "<group>";
+		};
+		01E8626F270E777A0085209A /* InputViews */ = {
+			isa = PBXGroup;
+			children = (
+				01E86272270E777A0085209A /* LabeledInputView.swift */,
+				01E86275270E777A0085209A /* TextFieldInputView.swift */,
+				01E86274270E777A0085209A /* TextBoxInputView.swift */,
+				01E86271270E777A0085209A /* NumberInputView.swift */,
+				01E86273270E777A0085209A /* SliderInputView.swift */,
+				01E86270270E777A0085209A /* TagInputView.swift */,
+			);
+			path = InputViews;
+			sourceTree = "<group>";
+		};
 		1336A31D241C400F00949F32 /* GymClassDataSource */ = {
 			isa = PBXGroup;
 			children = (
@@ -537,6 +578,7 @@
 				017C0B25251018BA00BFA80A /* Colors+MapMarker.swift */,
 				29570D4D2569DE990086741B /* Colors+Calendar.swift */,
 				01CDFF69257C614900D9FBD6 /* Colors+Resource.swift */,
+				01E86285270E78920085209A /* Colors+InputView.swift */,
 			);
 			path = Colors;
 			sourceTree = "<group>";
@@ -574,6 +616,7 @@
 		1396012D23865E2E005E4788 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				01E8626E270E777A0085209A /* InputView */,
 				303F6AE5236A9C0D007E37DD /* SegmentedControl */,
 				29387E9324BBBBDF00070BCE /* Bar Graph */,
 				2913595524B135B600DE9AD6 /* DetailView */,
@@ -1215,10 +1258,12 @@
 				55AF44292453A4EC00F13232 /* CafeDataSource.swift in Sources */,
 				29DB64CF25BA61BD001C4275 /* StudyGroupsView.swift in Sources */,
 				306A550023614C0000D59A7F /* MainContainerViewController.swift in Sources */,
+				01E86280270E77970085209A /* SampleFormViewController.swift in Sources */,
 				01CDBBE925CA6AF9006B93BD /* StudyPact+Endpoints.swift in Sources */,
 				2978F20625CA4C680010E3BA /* BorderedTextField.swift in Sources */,
 				29F11EC72516C150007DCFD7 /* BarView.swift in Sources */,
 				55DCF78723722CBD001B01B8 /* Colors.swift in Sources */,
+				01E86279270E777A0085209A /* LabeledInputView.swift in Sources */,
 				29B3D7862453984A006762E5 /* DrawerViewDelegate.swift in Sources */,
 				F0E4A47C25BCEC3000FF2256 /* StudyGroupDetailsViewController.swift in Sources */,
 				559AF6E0251EAA2800463E2A /* DetailTapGestureRecognizer.swift in Sources */,
@@ -1230,6 +1275,7 @@
 				FD6FB45F25C6A4B90045A03A /* StudyPactPreference.swift in Sources */,
 				557756692544D822009C03BD /* Collection+Extension.swift in Sources */,
 				5546CB91251B0A4500BE1876 /* UIDevice+Extensions.swift in Sources */,
+				01E8627D270E777A0085209A /* InputView.swift in Sources */,
 				2975D5402459301B00514B43 /* SearchDrawerViewDelegate.swift in Sources */,
 				01CDBBED25CA6F4D006B93BD /* Response.swift in Sources */,
 				133864A42404DCCA001F9048 /* MapMarker.swift in Sources */,
@@ -1237,6 +1283,7 @@
 				13491DBA241E23630033F9AB /* Colors+Text.swift in Sources */,
 				136DC97D2398B4F3009B1810 /* UIImage+Extensions.swift in Sources */,
 				55C6936B240E143500400B60 /* ResourceTableViewCell.swift in Sources */,
+				01E86278270E777A0085209A /* NumberInputView.swift in Sources */,
 				2978F20925CA4C6E0010E3BA /* ProfileLabel.swift in Sources */,
 				13135BB22412442C0056B169 /* FilterView.swift in Sources */,
 				29AB5BC5241D8CB4007C3ECA /* FilterTableView.swift in Sources */,
@@ -1282,6 +1329,7 @@
 				FD3D700225C2BC7D00579EF5 /* CreatePreferenceFrameViewController.swift in Sources */,
 				55DCF79B237243D4001B01B8 /* MaterialTextField.swift in Sources */,
 				554CB9A023F3A83F00BB1715 /* EventTableViewCell.swift in Sources */,
+				01E8627B270E777A0085209A /* TextBoxInputView.swift in Sources */,
 				01B250282516AD4F00CBA459 /* IconPairView.swift in Sources */,
 				55AF442B2453A80B00F13232 /* CafeItem.swift in Sources */,
 				FDD7946C260FE09D00ABE60E /* Colors+AlertView.swift in Sources */,
@@ -1338,6 +1386,7 @@
 				2946939F25F4421700619481 /* CalendarTablePairView.swift in Sources */,
 				2925D5FA2529405500BBA266 /* CampusEventCellView.swift in Sources */,
 				5516088624392E5100B1E55B /* DiningViewController.swift in Sources */,
+				01E8627C270E777A0085209A /* TextFieldInputView.swift in Sources */,
 				FD6FB45C25C62EB90045A03A /* SelectEnvironmentView.swift in Sources */,
 				29F09C3525D76EDF003FB69F /* StudyPactNewFeatureViewController.swift in Sources */,
 				01CDBBC725CA3B13006B93BD /* NetworkManager.swift in Sources */,
@@ -1356,6 +1405,7 @@
 				01CDBBF125CA6F58006B93BD /* RequestError.swift in Sources */,
 				01FA50F124E8B33100DCC490 /* LocationManager.swift in Sources */,
 				017C0B26251018BA00BFA80A /* Colors+MapMarker.swift in Sources */,
+				01E86277270E777A0085209A /* TagInputView.swift in Sources */,
 				29570D4C2569D8F20086741B /* CalendarView.swift in Sources */,
 				29345E2724A7E76300859A88 /* OverviewCardView.swift in Sources */,
 				01D11B902504560700BDF660 /* GymDetailViewController.swift in Sources */,
@@ -1372,6 +1422,7 @@
 				01CDFF6A257C614900D9FBD6 /* Colors+Resource.swift in Sources */,
 				13741B6C2400D866003D1EEB /* MapDataSource.swift in Sources */,
 				1336A320241D924300949F32 /* DiningItem.swift in Sources */,
+				01E86286270E78920085209A /* Colors+InputView.swift in Sources */,
 				299ACFB4244A5F90000F3E86 /* HasOccupancy.swift in Sources */,
 				55AA7B3325FD4F68002B4A4B /* CovidDataSource.swift in Sources */,
 				0181710A25CA90D300BA6317 /* AuthenticateUser.swift in Sources */,
@@ -1382,6 +1433,7 @@
 				29891B23257C521E0094891D /* PageViewController.swift in Sources */,
 				13EA64CD2399CEDA00FD8E13 /* Gym.swift in Sources */,
 				1396013523865E2E005E4788 /* CardView.swift in Sources */,
+				01E8627A270E777A0085209A /* SliderInputView.swift in Sources */,
 				1336A322241D92F700949F32 /* MealType.swift in Sources */,
 				303F6AE1236A931D007E37DD /* SegmentedControl.swift in Sources */,
 				5516088824393F3F00B1E55B /* MissingDataView.swift in Sources */,

--- a/berkeley-mobile/Assets/Colors/Colors+InputView.swift
+++ b/berkeley-mobile/Assets/Colors/Colors+InputView.swift
@@ -1,0 +1,54 @@
+//
+//  Colors+InputView.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 10/6/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension Color {
+    // Colors for user input fields
+    struct InputView {
+
+        static var placeholder: UIColor {
+            return UIColor(displayP3Red: 216/255, green: 216/255, blue: 216/255, alpha: 1.0)
+        }
+
+        static var unfocused: UIColor {
+            return UIColor(displayP3Red: 209/255, green: 209/255, blue: 209/255, alpha: 1.0)
+        }
+
+        static var focused: UIColor {
+            return UIColor(displayP3Red: 44/255, green: 44/255, blue: 45/255, alpha: 1.0)
+        }
+
+        static var selected: UIColor {
+            return UIColor(displayP3Red: 106/255, green: 145/255, blue: 255/255, alpha: 1.0)
+        }
+
+        static var radioBorder: UIColor {
+            return UIColor(displayP3Red: 151/255, green: 151/255, blue: 151/255, alpha: 1.0)
+        }
+
+        struct Tag {
+
+            static var cyan: UIColor {
+                return UIColor(displayP3Red: 102/255, green: 188/255, blue: 236/255, alpha: 1.0)
+            }
+
+            static var yellow: UIColor {
+                return UIColor(displayP3Red: 244/255, green: 196/255, blue: 121/255, alpha: 1.0)
+            }
+
+            // TODO: Fill out remaining tags.
+
+            static var all: [UIColor] {
+                return [cyan, yellow]
+            }
+        }
+    }
+
+}

--- a/berkeley-mobile/Common/InputView/InputView.swift
+++ b/berkeley-mobile/Common/InputView/InputView.swift
@@ -1,0 +1,65 @@
+//
+//  InputView.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 5/5/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/** A view that gathers user input. */
+protocol InputView: UIView {
+
+    /// The user's currently-inputted value.
+    var value: Any { get }
+
+    /// A unique identifier for this field.
+    var id: String { get }
+}
+
+/** A selection choice in an input field. This is a tuple of (identifier, display string) for the option. */
+typealias InputOption = (id: String, display: String)
+
+enum InputType {
+
+    /// A single-line text input field.
+    case textField(placeholder: String?)
+
+    /// A multi-line text input field.
+    case textBox(placeholder: String?)
+
+    /// Select an integer in the range [`min`, `max`].
+    case number(min: Int, max: Int)
+
+    /// Select on a range between two options.
+    case slider(notches: Int, leftLabel: String, rightLabel: String)
+
+    /// Single-selection from a list of strings.
+    case singleSelection(selections: [InputOption])
+
+    /// Dropdown single-selection from a list of strings.
+    case dropdownSingleSelection(selections: [InputOption])
+
+    /// Multi-selection from a set of tags.
+    case tagMultiSelection(selections: [InputTagType])
+
+    /** Returns the view corresponding to the input type. */
+    public func inputView(id: String, label: String) -> InputView {
+        switch self {
+        case .textField(let placeholder):
+            return TextFieldInputView(id: id, label: label, placeholder: placeholder)
+        case .textBox(let placeholder):
+            return TextBoxInputView(id: id, label: label, placeholder: placeholder)
+        case .number(let min, let max):
+            return NumberInputView(id: id, label: label, min: min, max: max)
+        case .slider(let notches, let leftLabel, let rightlabel):
+            return SliderInputView(id: id, notches: notches, leftLabel: leftLabel, rightLabel: rightlabel)
+        default:
+            // TODO: Placeholder
+            return TextFieldInputView(id: id, label: label, placeholder: "TODO: Placeholder")
+        }
+    }
+
+}

--- a/berkeley-mobile/Common/InputView/InputViews/LabeledInputView.swift
+++ b/berkeley-mobile/Common/InputView/InputViews/LabeledInputView.swift
@@ -1,0 +1,43 @@
+//
+//  TwoColumnInputView.swift
+//  FormTestApp
+//
+//  Created by Kevin Hu on 9/5/21.
+//
+
+import UIKit
+
+class LabeledInputView: UIView {
+
+    // MARK: UI Elements
+
+    public var stackView: UIStackView!
+    public var fieldLabel: UILabel!
+
+    init(label: String, leftColumnWidth: CGFloat = 85) {
+        super.init(frame: .zero)
+
+        stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        stackView.spacing = 15
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor).isActive = true
+        stackView.leftAnchor.constraint(equalTo: layoutMarginsGuide.leftAnchor).isActive = true
+        stackView.rightAnchor.constraint(equalTo: layoutMarginsGuide.rightAnchor).isActive = true
+
+        fieldLabel = UILabel()
+        fieldLabel.text = label
+        fieldLabel.font = Font.regular(13)
+        fieldLabel.numberOfLines = 0
+        fieldLabel.widthAnchor.constraint(equalToConstant: leftColumnWidth).isActive = true
+        stackView.addArrangedSubview(fieldLabel)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/berkeley-mobile/Common/InputView/InputViews/NumberInputView.swift
+++ b/berkeley-mobile/Common/InputView/InputViews/NumberInputView.swift
@@ -1,0 +1,121 @@
+//
+//  NumberInputView.swift
+//  FormTestApp
+//
+//  Created by Kevin Hu on 9/26/21.
+//
+
+import UIKit
+
+private let kMaxButtonsPerRow: Int = 5
+
+class NumberInputView: LabeledInputView, InputView {
+
+    // MARK: InputView Fields
+
+    var id: String
+    var value: Any {
+        return buttonSelected?.number as Any
+    }
+
+    // MARK: Private Fields
+
+    private var buttonSelected: GroupNumberButton?
+
+    init(id: String, label: String, min: Int, max: Int) {
+        self.id = id
+        super.init(label: label)
+
+        let stackY = UIStackView()
+        stackY.axis = .vertical
+        stackY.distribution = .equalSpacing
+
+        let rows: Int = Int(ceil(Double(max - min + 1) / Double(kMaxButtonsPerRow)))
+        var currentInt: Int = min
+        for _ in 1...rows {
+            let stackX = UIStackView()
+            stackX.axis = .horizontal
+            stackX.distribution = .equalSpacing
+            stackX.translatesAutoresizingMaskIntoConstraints = false
+            let items = kMaxButtonsPerRow < max - currentInt + 1 ? kMaxButtonsPerRow : max - currentInt + 1
+            for _ in 1...items {
+                let btn = buttonGenerator(num: currentInt)
+                stackX.addArrangedSubview(btn)
+                currentInt += 1
+            }
+            stackY.addArrangedSubview(stackX)
+        }
+
+        stackView.alignment = .top
+        stackView.addArrangedSubview(stackY)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func buttonGenerator(num: Int) -> UIButton {
+        let btn = GroupNumberButton(number: num)
+        btn.setTitleColor(Color.blackText, for: .normal)
+        btn.titleLabel?.font = Font.regular(14)
+        btn.contentMode = .scaleAspectFit
+        btn.translatesAutoresizingMaskIntoConstraints = false
+
+        let radius: CGFloat = 15
+        btn.widthAnchor.constraint(equalToConstant: 2 * radius).isActive = true
+        btn.heightAnchor.constraint(equalToConstant: 2 * radius).isActive = true
+        btn.layer.cornerRadius = radius
+        btn.addTarget(self, action: #selector(toggleButton(sender:)), for: .touchUpInside)
+
+        return btn
+    }
+
+    @objc private func toggleButton(sender: GroupNumberButton) {
+        if !sender.isSelected {
+            sender.backgroundColor = Color.InputView.selected
+            sender.setTitleColor(.white, for: .normal)
+            sender.isSelected.toggle()
+            sender.border?.isHidden = true
+
+            if let buttonSelected = self.buttonSelected {
+                buttonSelected.border?.isHidden = false
+                buttonSelected.backgroundColor = nil
+                buttonSelected.setTitleColor(Color.blackText, for: .normal)
+                buttonSelected.isSelected.toggle()
+            }
+            self.buttonSelected = sender
+        }
+    }
+
+}
+
+private class GroupNumberButton: UIButton {
+
+    let number: Int
+    var border: CAShapeLayer?
+
+    init(number: Int) {
+        self.number = number
+        super.init(frame: .zero)
+        self.setTitle(String(number), for: .normal)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if border == nil {
+            let bounds = self.bounds
+            border = CAShapeLayer.init()
+            guard let border = border else { return }
+            let path = UIBezierPath(roundedRect: bounds, cornerRadius: self.layer.cornerRadius)
+            border.path = path.cgPath
+            border.strokeColor = Color.InputView.focused.cgColor
+            border.lineDashPattern = [2, 2]
+            border.fillColor = nil
+            self.layer.addSublayer(border)
+        }
+    }
+}

--- a/berkeley-mobile/Common/InputView/InputViews/SliderInputView.swift
+++ b/berkeley-mobile/Common/InputView/InputViews/SliderInputView.swift
@@ -1,0 +1,108 @@
+//
+//  SliderInputView.swift
+//  FormTestApp
+//
+//  Created by Kevin Hu on 9/26/21.
+//
+
+import UIKit
+
+class SliderInputView: UIView, InputView {
+
+    // MARK: InputView Fields
+
+    var id: String
+    var value: Any {
+        return buttonSelected?.id as Any
+    }
+
+    // MARK: UI Elements
+
+    private var stackView: UIStackView!
+    private var lineLayer: CAShapeLayer?
+    private var buttonSelected: NotchButton?
+
+    init(id: String, notches: Int, leftLabel: String, rightLabel: String) {
+        self.id = id
+        super.init(frame: .zero)
+
+        stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .equalSpacing
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor).isActive = true
+        stackView.leftAnchor.constraint(equalTo: layoutMarginsGuide.leftAnchor).isActive = true
+        stackView.rightAnchor.constraint(equalTo: layoutMarginsGuide.rightAnchor).isActive = true
+
+        for i in 0..<notches {
+            let btn = buttonGenerator(id: i)
+            stackView.addArrangedSubview(btn)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let line = lineLayer ?? CAShapeLayer()
+        let lineBounds = CGRect(x: 0, y: (bounds.height - 3.5) / 2, width: bounds.width, height: 3.5)
+        let path = UIBezierPath(roundedRect: lineBounds, cornerRadius: lineBounds.height / 2)
+        line.path = path.cgPath
+        line.fillColor = Color.InputView.radioBorder.cgColor
+        line.opacity = 1.0
+        layer.insertSublayer(line, at: 0)
+        lineLayer = line
+    }
+
+    func buttonGenerator(id: Int) -> UIButton {
+        let btn = NotchButton(id: id)
+        btn.contentMode = .scaleAspectFit
+        btn.translatesAutoresizingMaskIntoConstraints = false
+
+        let radius: CGFloat = 10
+        btn.widthAnchor.constraint(equalToConstant: 2 * radius).isActive = true
+        btn.heightAnchor.constraint(equalToConstant: 2 * radius).isActive = true
+        btn.layer.cornerRadius = radius
+        btn.layer.borderColor = Color.InputView.radioBorder.cgColor
+        btn.layer.borderWidth = 3.5
+        btn.backgroundColor = .white
+        btn.addTarget(self, action: #selector(toggleButton(sender:)), for: .touchUpInside)
+
+        return btn
+    }
+
+    @objc private func toggleButton(sender: NotchButton) {
+        if !sender.isSelected {
+            sender.backgroundColor = Color.InputView.selected
+            sender.layer.borderColor = Color.InputView.selected.cgColor
+            sender.isSelected.toggle()
+
+            if let buttonSelected = self.buttonSelected {
+                buttonSelected.backgroundColor = .white
+                buttonSelected.layer.borderColor = Color.InputView.radioBorder.cgColor
+                buttonSelected.isSelected.toggle()
+            }
+            self.buttonSelected = sender
+        }
+    }
+
+}
+
+private class NotchButton: UIButton {
+
+    let id: Int
+
+    init(id: Int) {
+        self.id = id
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/berkeley-mobile/Common/InputView/InputViews/TagInputView.swift
+++ b/berkeley-mobile/Common/InputView/InputViews/TagInputView.swift
@@ -1,0 +1,103 @@
+//
+//  TagInputView.swift
+//  FormTestApp
+//
+//  Created by Kevin Hu on 10/6/21.
+//
+
+import UIKit
+
+typealias InputTagType = (option: InputOption, color: UIColor)
+
+class TagInputView: LabeledInputView, InputView {
+
+    // MARK: InputView Fields
+
+    var id: String
+    var value: Any {
+        return selectedTags.map { $0.option.id }
+    }
+
+    // MARK: UI Elements
+
+    private var rhsView: UIView!
+    private var cardView: CardView!
+    private var textField: UITextField!
+    private var resultsView: UITableView!
+    private var collectionView: UICollectionView!
+
+    private var selectedTags: [InputTagType] = []
+
+    init(id: String, label: String, selections: [InputTagType]) {
+        self.id = id
+        super.init(label: label)
+
+        rhsView = UIView()
+
+        cardView = CardView()
+        cardView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        rhsView.addSubview(cardView)
+        cardView.translatesAutoresizingMaskIntoConstraints = false
+        cardView.topAnchor.constraint(equalTo: rhsView.topAnchor).isActive = true
+        cardView.leftAnchor.constraint(equalTo: rhsView.leftAnchor).isActive = true
+        cardView.rightAnchor.constraint(equalTo: rhsView.rightAnchor).isActive = true
+
+        textField = UITextField()
+        textField.delegate = self
+        textField.textColor = Color.blackText
+        textField.font = Font.regular(12)
+        let padding = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 10, height: 1.0))
+        let rightIconView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 23, height: 11))
+        let searchIcon = UIImageView(image: UIImage(named: "Search")?
+                                        .resized(size: CGSize(width: 11, height: 11)))
+        searchIcon.frame = CGRect(x: 0.0, y: 0.0, width: 11, height: 11)
+        searchIcon.contentMode = .center
+        rightIconView.addSubview(searchIcon)
+        textField.leftView = padding
+        textField.rightView = rightIconView
+        textField.leftViewMode = .always
+        textField.rightViewMode = .always
+        cardView.addSubview(textField)
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.heightAnchor.constraint(equalToConstant: 26).isActive = true
+        textField.topAnchor.constraint(equalTo: cardView.layoutMarginsGuide.topAnchor).isActive = true
+        textField.leftAnchor.constraint(equalTo: cardView.layoutMarginsGuide.leftAnchor).isActive = true
+        textField.rightAnchor.constraint(equalTo: cardView.layoutMarginsGuide.rightAnchor).isActive = true
+
+        resultsView = UITableView()
+        cardView.addSubview(resultsView)
+        resultsView.translatesAutoresizingMaskIntoConstraints = false
+        resultsView.topAnchor.constraint(equalTo: textField.bottomAnchor).isActive = true
+        resultsView.leftAnchor.constraint(equalTo: cardView.layoutMarginsGuide.leftAnchor).isActive = true
+        resultsView.rightAnchor.constraint(equalTo: cardView.layoutMarginsGuide.rightAnchor).isActive = true
+        resultsView.bottomAnchor.constraint(equalTo: cardView.layoutMarginsGuide.bottomAnchor).isActive = true
+
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 10
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        rhsView.addSubview(collectionView)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.topAnchor.constraint(equalTo: cardView.bottomAnchor, constant: 10).isActive = true
+        collectionView.leftAnchor.constraint(equalTo: rhsView.leftAnchor).isActive = true
+        collectionView.rightAnchor.constraint(equalTo: rhsView.rightAnchor).isActive = true
+        collectionView.bottomAnchor.constraint(equalTo: rhsView.bottomAnchor).isActive = true
+
+        stackView.addArrangedSubview(rhsView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+extension TagInputView: UITextFieldDelegate {
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+    }
+
+}

--- a/berkeley-mobile/Common/InputView/InputViews/TextBoxInputView.swift
+++ b/berkeley-mobile/Common/InputView/InputViews/TextBoxInputView.swift
@@ -1,0 +1,74 @@
+//
+//  TextBoxInputView.swift
+//  FormTestApp
+//
+//  Created by Kevin Hu on 9/5/21.
+//
+
+import UIKit
+
+class TextBoxInputView: LabeledInputView, InputView {
+
+    // MARK: InputView Fields
+
+    var id: String
+    var value: Any {
+        if textView.textColor == placeholderColor { return "" }
+        return textView.text ?? ""
+    }
+
+    // MARK: UI Elements
+
+    private var textView: UITextView!
+
+    private var placeholder: String
+    private var placeholderColor: UIColor = Color.InputView.placeholder
+    private var textColor: UIColor = Color.blackText
+
+    init(id: String, label: String, placeholder: String?) {
+        self.id = id
+        self.placeholder = placeholder ?? ""
+        super.init(label: label)
+
+        textView = UITextView()
+        textView.delegate = self
+        textView.text = placeholder
+        textView.textColor = placeholderColor
+        textView.font = Font.regular(12)
+        textView.layer.cornerRadius = 5
+        textView.layer.borderWidth = 1.5
+        textView.layer.borderColor = Color.InputView.unfocused.cgColor
+        textView.textContainerInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        textView.heightAnchor.constraint(equalToConstant: 250).isActive = true
+
+        stackView.alignment = .top
+        stackView.addArrangedSubview(textView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+extension TextBoxInputView: UITextViewDelegate {
+
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        // Change border color on focus
+        textView.animateBorderColor(toColor: Color.InputView.focused, duration: 0.1)
+        if textView.textColor == placeholderColor {
+            textView.text = nil
+            textView.textColor = textColor
+        }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        // Reset border color when ending focus
+        textView.animateBorderColor(toColor: Color.InputView.unfocused, duration: 0.1)
+        if textView.text.isEmpty {
+            textView.text = placeholder
+            textView.textColor = placeholderColor
+        }
+    }
+
+}

--- a/berkeley-mobile/Common/InputView/InputViews/TextFieldInputView.swift
+++ b/berkeley-mobile/Common/InputView/InputViews/TextFieldInputView.swift
@@ -1,0 +1,66 @@
+//
+//  TextFieldInputView.swift
+//  berkeley-mobile
+//
+//  Created by Kevin Hu on 5/5/21.
+//  Copyright © 2021 ASUC OCTO. All rights reserved.
+//
+
+import UIKit
+
+class TextFieldInputView: LabeledInputView, InputView {
+
+    // MARK: InputView Fields
+
+    var id: String
+    var value: Any {
+        return textField.text ?? ""
+    }
+
+    // MARK: UI Elements
+
+    private var textField: UITextField!
+
+    init(id: String, label: String, placeholder: String?) {
+        self.id = id
+        super.init(label: label)
+
+        textField = UITextField()
+        textField.delegate = self
+        textField.layer.cornerRadius = 5
+        textField.layer.borderWidth = 1.5
+        textField.layer.borderColor = Color.InputView.unfocused.cgColor
+        textField.textColor = Color.blackText
+        textField.font = Font.regular(12)
+        textField.attributedPlaceholder = NSAttributedString(string: placeholder ?? "", attributes: [
+            NSAttributedString.Key.foregroundColor: Color.InputView.placeholder,
+            NSAttributedString.Key.font: Font.regular(12)
+        ])
+        let padding = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 15, height: 1.0))
+        textField.leftView = padding
+        textField.rightView = padding
+        textField.leftViewMode = .always
+        textField.rightViewMode = .always
+        textField.heightAnchor.constraint(equalToConstant: 36).isActive = true
+
+        stackView.addArrangedSubview(textField)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension TextFieldInputView: UITextFieldDelegate {
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        // Change border color on focus
+        textField.animateBorderColor(toColor: Color.InputView.focused, duration: 0.1)
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        // Reset border color when ending focus
+        textField.animateBorderColor(toColor: Color.InputView.unfocused, duration: 0.1)
+    }
+
+}

--- a/berkeley-mobile/Common/InputView/SampleFormViewController.swift
+++ b/berkeley-mobile/Common/InputView/SampleFormViewController.swift
@@ -1,0 +1,70 @@
+//
+//  FormViewController.swift
+//  FormTestApp
+//
+//  Created by Kevin Hu on 9/5/21.
+//
+
+import UIKit
+
+class SampleFormViewController: UIViewController {
+
+    /// A stack view containing all the input views.
+    private var stackView: UIStackView!
+
+    /// The list of fields to be displayed in the form, in order.
+    private var formFields: [(id: String, label: String, type: InputType)]! {
+        didSet {
+            //stackView.removeAllArrangedSubviews()
+            for view in stackView.arrangedSubviews {
+                stackView.removeArrangedSubview(view)
+                view.removeFromSuperview()
+            }
+            _ = formFields.map { stackView.addArrangedSubview($0.type.inputView(id: $0.id, label: $0.label)) }
+        }
+    }
+
+    /// Returns the user's selected values for this form.
+    public var formValues: [String: Any] {
+        Dictionary(uniqueKeysWithValues: stackView.arrangedSubviews.compactMap { view in
+            guard let inputView = view as? InputView else { return nil }
+            return (inputView.id, inputView.value)
+        })
+    }
+
+    @objc func submitForm() {
+        print(formValues)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .white
+
+        stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 15
+        stackView.distribution = .fill
+        view.addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor).isActive = true
+        stackView.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
+        stackView.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
+
+        // TODO: This is a placeholder for testing
+        formFields = [
+            (id: "pronouns", label: "Pronouns", type: .textField(placeholder: "he/him/his")),
+            (id: "bio", label: "Bio", type: .textBox(placeholder: "A little bit about you!")),
+            (id: "roommate_count", label: "Preferred # of roomates", type: .number(min: 1, max: 5)),
+            (id: "personality", label: "", type: .slider(notches: 5, leftLabel: "Introverted", rightLabel: "Extroverted"))
+        ]
+
+        let button = UIButton()
+        button.setTitle("Get Values", for: .normal)
+        button.setTitleColor(UIColor.white, for: .normal)
+        button.backgroundColor = UIColor.black
+        button.addTarget(self, action: #selector(submitForm), for: .touchUpInside)
+        stackView.addArrangedSubview(button)
+    }
+}
+

--- a/berkeley-mobile/Utils/UIView+Extensions.swift
+++ b/berkeley-mobile/Utils/UIView+Extensions.swift
@@ -97,3 +97,16 @@ extension UIView {
         NSLayoutConstraint(item: self, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: width).isActive = true
     }
 }
+
+extension UIView {
+
+    // Shamelessly stolen from: https://stackoverflow.com/questions/28934948/how-to-animate-bordercolor-change-in-swift
+    func animateBorderColor(toColor: UIColor, duration: Double) {
+        let animation = CABasicAnimation(keyPath: "borderColor")
+        animation.fromValue = layer.borderColor
+        animation.toValue = toColor.cgColor
+        animation.duration = duration
+        layer.add(animation, forKey: "borderColor")
+        layer.borderColor = toColor.cgColor
+    }
+}


### PR DESCRIPTION
Adds some common input fields that can be used across the app (using the figma for roommate finder as a reference). Includes a `SampleFormViewController` for a rough example of how these views could be added to a form and how the user-inputted values could be retrieved.
- Text field (single line text input)
- Text box (multi line text input)
- Number
- Discrete slider

Other input types (multiple tag selection, dropdown, etc.) are not implemented in this PR, as those changes will require significant work, and I would like to avoid this PR from becoming too large.