### PR TITLE
Hotfix: Compass not being hidden on search results

### DIFF
--- a/berkeley-mobile/Map/MapViewController.swift
+++ b/berkeley-mobile/Map/MapViewController.swift
@@ -133,7 +133,7 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
         if compass != nil { return }
         mapView.showsCompass = false
         compass = MKCompassButton(mapView: mapView)
-        view.addSubview(compass)
+        view.insertSubview(compass, belowSubview: maskView)
         // Position the compass to bottom-right of `FilterView`
         compass.translatesAutoresizingMaskIntoConstraints = false
         compass.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
@@ -210,14 +210,12 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
             self.searchResultsView.isHidden = false
             mainContainer?.hideTop()
             self.userLocationButton.isHidden = true
-            self.compass?.isHidden = true
         } else {
             self.maskView.isHidden = true
             self.searchResultsView.isHidden = true
             self.searchResultsView.isScrolling = false
             mainContainer?.showTop()
             self.userLocationButton?.isHidden = false
-            self.compass?.isHidden = false
         }
     }
     

--- a/berkeley-mobile/Map/MapViewController.swift
+++ b/berkeley-mobile/Map/MapViewController.swift
@@ -130,6 +130,7 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
 
     /// Repoisitions the map's compass so that it is not obscured by the search bar.
     private func updateCompassPosition() {
+        if compass != nil { return }
         mapView.showsCompass = false
         compass = MKCompassButton(mapView: mapView)
         view.addSubview(compass)


### PR DESCRIPTION
After switching to a different tab, then switching back to the map, the compass would no longer be hidden when the search results were up. Fixes this issue.