### PR TITLE
fix: broken constraint and calendar select bugs

### DIFF
--- a/berkeley-mobile/Common/Calendar/CalendarTablePairView.swift
+++ b/berkeley-mobile/Common/Calendar/CalendarTablePairView.swift
@@ -108,7 +108,11 @@ extension CalendarTablePairView: CalendarViewDelegate {
         }
         tableEntries = selectedEntries
         calendarTable.reloadData()
-        calendarTableHeightConstraint?.constant = min(calendarTable.contentSize.height, self.frame.height * 0.7)
+        if selectedEntries.isEmpty {
+            calendarTableHeightConstraint?.constant = self.frame.height * 0.2
+        } else {
+            calendarTableHeightConstraint?.constant = min(calendarTable.contentSize.height, self.frame.height * 0.7)
+        }
         self.layoutIfNeeded()
     }
 }

--- a/berkeley-mobile/Common/Calendar/CalendarView.swift
+++ b/berkeley-mobile/Common/Calendar/CalendarView.swift
@@ -184,6 +184,7 @@ class CalendarCell: UICollectionViewCell {
     public func configureHeader(text: String) {
         label.text = text
         label.textColor = Color.Calendar.dayOfWeekHeader
+        label.font = Font.light(18)
         highlightView.backgroundColor = .clear
     }
     
@@ -247,7 +248,7 @@ extension CalendarView: UICollectionViewDelegate, UICollectionViewDataSource {
                 let calendarDay = calendarDays[cellIndex]
                 // highlight and bold the text if the cell is for today
                 let todayComponents = calendar.dateComponents([.year, .month, .day], from: Date())
-                let boldText = year == todayComponents.year && month == todayComponents.month && calendarDay.day == todayComponents.day
+                let boldText = year == todayComponents.year && month == todayComponents.month && calendarDay.day == todayComponents.day && calendarDay.isCurrentMonth
                 calendarCell.configureDay(entries: currentMonthCalendarEntries, calendarDay: calendarDay, boldText: boldText)
             }
         }

--- a/berkeley-mobile/Common/Calendar/MonthSelectorView.swift
+++ b/berkeley-mobile/Common/Calendar/MonthSelectorView.swift
@@ -30,7 +30,7 @@ class MonthSelectorView: UIView {
             if Date() > lastDate {
                 lastDate = Date()
             }
-            let lastComponents = Calendar.current.dateComponents([.month, .year], from: lastDate > Date() ? lastDate : Date())
+            let lastComponents = Calendar.current.dateComponents([.month, .year], from: lastDate)
             months = []
             // add every month from the earliest entry to the latest entry
             for year in firstComponents.year!...lastComponents.year! {

--- a/berkeley-mobile/Common/Calendar/MonthSelectorView.swift
+++ b/berkeley-mobile/Common/Calendar/MonthSelectorView.swift
@@ -15,13 +15,22 @@ class MonthSelectorView: UIView {
             let sortedCalendarEntries = calendarEntries.sorted(by: { entry1, entry2 in
                 return entry1.date < entry2.date
             })
-            guard let firstDate = sortedCalendarEntries.first?.date,
-                  let lastDate = sortedCalendarEntries.last?.date else {
+            guard var firstDate = sortedCalendarEntries.first?.date,
+                  var lastDate = sortedCalendarEntries.last?.date else {
                 months = [(initialMonth, initialYear)]
                 return
             }
+            // calendar should only go back at most 1 year
+            if let oneYearAgo = Calendar.current.date(byAdding: .year, value: -1, to: Date()),
+               oneYearAgo > firstDate {
+                firstDate = oneYearAgo
+            }
             let firstComponents = Calendar.current.dateComponents([.month, .year], from: firstDate)
-            let lastComponents = Calendar.current.dateComponents([.month, .year], from: lastDate)
+            // calendar should always go up until the current day at least
+            if Date() > lastDate {
+                lastDate = Date()
+            }
+            let lastComponents = Calendar.current.dateComponents([.month, .year], from: lastDate > Date() ? lastDate : Date())
             months = []
             // add every month from the earliest entry to the latest entry
             for year in firstComponents.year!...lastComponents.year! {


### PR DESCRIPTION
fix broken constraint for MissingDataView on Academic Calendar page: missing data view should now be shown properly (before it didn't appear)

set month limits for calendar to be from at most one year ago to at least current day (before it was determined only by the months where we had event data. this meant the calendar started in 2020 and ended before present day because we don't have up-to-date data)

fixed some other text bolding issues related to the calendar