### PR TITLE
profile page phone number add example

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		01B2502F2516C45800CBA459 /* EventCalendarEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B2502E2516C45800CBA459 /* EventCalendarEntry.swift */; };
 		01BC8EB024E8C3E3005B4969 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BC8EAF24E8C3E3005B4969 /* DetailView.swift */; };
 		01C75E2E25292E5B00C25A32 /* DescriptionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C75E2D25292E5B00C25A32 /* DescriptionCardView.swift */; };
-		01CDBB9925CA32AF006B93BD /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBB9825CA32AF006B93BD /* Secrets.swift */; };
 		01CDBBC725CA3B13006B93BD /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBBC625CA3B13006B93BD /* NetworkManager.swift */; };
 		01CDBBE925CA6AF9006B93BD /* StudyPact+Endpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBBE825CA6AF9006B93BD /* StudyPact+Endpoints.swift */; };
 		01CDBBED25CA6F4D006B93BD /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBBEC25CA6F4D006B93BD /* Response.swift */; };
@@ -92,7 +91,6 @@
 		13EA64CA2399CE5B00FD8E13 /* SearchItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EA64C92399CE5B00FD8E13 /* SearchItem.swift */; };
 		13EA64CD2399CEDA00FD8E13 /* Gym.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EA64CC2399CEDA00FD8E13 /* Gym.swift */; };
 		13EA64D02399D50C00FD8E13 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EA64CF2399D50C00FD8E13 /* DataManager.swift */; };
-		29010C7A2539648B00CDA48A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 29010C792539648B00CDA48A /* GoogleService-Info.plist */; };
 		29061D41241C450E002BC9D9 /* HasLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29061D40241C450E002BC9D9 /* HasLocation.swift */; };
 		2913595724B136BE00DE9AD6 /* CollapsibleCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2913595624B136BE00DE9AD6 /* CollapsibleCardView.swift */; };
 		2913595924B13DF200DE9AD6 /* OpenTimesCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2913595824B13DF200DE9AD6 /* OpenTimesCardView.swift */; };
@@ -188,6 +186,10 @@
 		55DCF79B237243D4001B01B8 /* MaterialTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCF79A237243D4001B01B8 /* MaterialTextField.swift */; };
 		55DCF79D237243F5001B01B8 /* RippleLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCF79C237243F5001B01B8 /* RippleLayer.swift */; };
 		55DCF7A123724835001B01B8 /* MaterialButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCF7A023724835001B01B8 /* MaterialButton.swift */; };
+		BEA2779728DE8D1100511D9E /* .. in Resources */ = {isa = PBXBuildFile; fileRef = BEA2779628DE8D1100511D9E /* .. */; };
+		BEA2779928DE8D1B00511D9E /* Downloads in Sources */ = {isa = PBXBuildFile; fileRef = BEA2779828DE8D1A00511D9E /* Downloads */; };
+		BEC2861128ECD0D1008DAE2A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BEC2861028ECD0D1008DAE2A /* GoogleService-Info.plist */; };
+		BEC2861328ECD0DA008DAE2A /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC2861228ECD0DA008DAE2A /* Secrets.swift */; };
 		F07EDD8C25C626FE0097C813 /* GroupMembersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07EDD8B25C626FE0097C813 /* GroupMembersView.swift */; };
 		F0E4A47C25BCEC3000FF2256 /* StudyGroupDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E4A47B25BCEC3000FF2256 /* StudyGroupDetailsViewController.swift */; };
 		FD3D6FFF25C2BB7D00579EF5 /* SelectPeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3D6FFE25C2BB7D00579EF5 /* SelectPeopleView.swift */; };
@@ -220,7 +222,6 @@
 		01B2502E2516C45800CBA459 /* EventCalendarEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventCalendarEntry.swift; sourceTree = "<group>"; };
 		01BC8EAF24E8C3E3005B4969 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		01C75E2D25292E5B00C25A32 /* DescriptionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionCardView.swift; sourceTree = "<group>"; };
-		01CDBB9825CA32AF006B93BD /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		01CDBBC625CA3B13006B93BD /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		01CDBBE825CA6AF9006B93BD /* StudyPact+Endpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StudyPact+Endpoints.swift"; sourceTree = "<group>"; };
 		01CDBBEC25CA6F4D006B93BD /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
@@ -286,7 +287,6 @@
 		13EA64C92399CE5B00FD8E13 /* SearchItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchItem.swift; sourceTree = "<group>"; };
 		13EA64CC2399CEDA00FD8E13 /* Gym.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gym.swift; sourceTree = "<group>"; };
 		13EA64CF2399D50C00FD8E13 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
-		29010C792539648B00CDA48A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		29061D40241C450E002BC9D9 /* HasLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasLocation.swift; sourceTree = "<group>"; };
 		2913595624B136BE00DE9AD6 /* CollapsibleCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleCardView.swift; sourceTree = "<group>"; };
 		2913595824B13DF200DE9AD6 /* OpenTimesCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTimesCardView.swift; sourceTree = "<group>"; };
@@ -388,6 +388,10 @@
 		55DCF79C237243F5001B01B8 /* RippleLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RippleLayer.swift; sourceTree = "<group>"; };
 		55DCF7A023724835001B01B8 /* MaterialButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterialButton.swift; sourceTree = "<group>"; };
 		61110ED9482F3D5A5CFFE6B9 /* Pods-berkeley-mobile.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-berkeley-mobile.release.xcconfig"; path = "Target Support Files/Pods-berkeley-mobile/Pods-berkeley-mobile.release.xcconfig"; sourceTree = "<group>"; };
+		BEA2779628DE8D1100511D9E /* .. */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = ..; path = ../..; sourceTree = "<group>"; };
+		BEA2779828DE8D1A00511D9E /* Downloads */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = Downloads; path = ../../../Downloads; sourceTree = "<group>"; };
+		BEC2861028ECD0D1008DAE2A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		BEC2861228ECD0DA008DAE2A /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Secrets.swift; path = ../../../Downloads/Secrets.swift; sourceTree = "<group>"; };
 		F07EDD8B25C626FE0097C813 /* GroupMembersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupMembersView.swift; sourceTree = "<group>"; };
 		F0E4A47B25BCEC3000FF2256 /* StudyGroupDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyGroupDetailsViewController.swift; sourceTree = "<group>"; };
 		F9CAC9CEE1078D95B189B835 /* Pods_berkeley_mobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_berkeley_mobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -925,8 +929,10 @@
 				306A54F223613E3D00D59A7F /* Assets.xcassets */,
 				306A54F423613E3D00D59A7F /* LaunchScreen.storyboard */,
 				306A54F723613E3D00D59A7F /* Info.plist */,
-				29010C792539648B00CDA48A /* GoogleService-Info.plist */,
-				01CDBB9825CA32AF006B93BD /* Secrets.swift */,
+				BEC2861028ECD0D1008DAE2A /* GoogleService-Info.plist */,
+				BEC2861228ECD0DA008DAE2A /* Secrets.swift */,
+				BEA2779828DE8D1A00511D9E /* Downloads */,
+				BEA2779628DE8D1100511D9E /* .. */,
 			);
 			path = "berkeley-mobile";
 			sourceTree = "<group>";
@@ -1111,10 +1117,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BEC2861128ECD0D1008DAE2A /* GoogleService-Info.plist in Resources */,
+				BEA2779728DE8D1100511D9E /* .. in Resources */,
 				01D269952544D86C000377B4 /* Apercu Light Italic.otf in Resources */,
 				306A54F623613E3D00D59A7F /* LaunchScreen.storyboard in Resources */,
 				306A54F323613E3D00D59A7F /* Assets.xcassets in Resources */,
-				29010C7A2539648B00CDA48A /* GoogleService-Info.plist in Resources */,
 				01D269962544D86C000377B4 /* Apercu Bold Italic.otf in Resources */,
 				01D269942544D86C000377B4 /* Apercu Italic.otf in Resources */,
 				01D269992544D86C000377B4 /* Apercu Medium Italic.otf in Resources */,
@@ -1193,6 +1200,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				130FA59F243B12B3005DC752 /* Resource.swift in Sources */,
+				BEC2861328ECD0DA008DAE2A /* Secrets.swift in Sources */,
+				BEA2779928DE8D1B00511D9E /* Downloads in Sources */,
 				13B8E9592425819D00E7FCBF /* ResourceDataSource.swift in Sources */,
 				01FA50F324E8BA5400DCC490 /* LocationDetailView.swift in Sources */,
 				29CB28092404DD53009A2CFB /* StudyViewController.swift in Sources */,
@@ -1275,7 +1284,6 @@
 				13EA64CA2399CE5B00FD8E13 /* SearchItem.swift in Sources */,
 				13491DB8241E22130033F9AB /* Colors+Event.swift in Sources */,
 				13B39A9923E6A33C0039FBA2 /* Library.swift in Sources */,
-				01CDBB9925CA32AF006B93BD /* Secrets.swift in Sources */,
 				303F6AE4236A931D007E37DD /* SegmentedControlViewController.swift in Sources */,
 				559A7B6F2373DF39004EA501 /* SearchResultCell.swift in Sources */,
 				FDE7CD9925BCE6DB00F65A13 /* CreatePreferenceViewController.swift in Sources */,
@@ -1438,7 +1446,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1492,7 +1500,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -186,10 +186,10 @@
 		55DCF79B237243D4001B01B8 /* MaterialTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCF79A237243D4001B01B8 /* MaterialTextField.swift */; };
 		55DCF79D237243F5001B01B8 /* RippleLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCF79C237243F5001B01B8 /* RippleLayer.swift */; };
 		55DCF7A123724835001B01B8 /* MaterialButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCF7A023724835001B01B8 /* MaterialButton.swift */; };
+		BE18B9A328F0FC2500FF72A9 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE18B9A228F0FC2500FF72A9 /* Secrets.swift */; };
+		BE18B9A528F0FC2D00FF72A9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BE18B9A428F0FC2D00FF72A9 /* GoogleService-Info.plist */; };
 		BEA2779728DE8D1100511D9E /* .. in Resources */ = {isa = PBXBuildFile; fileRef = BEA2779628DE8D1100511D9E /* .. */; };
 		BEA2779928DE8D1B00511D9E /* Downloads in Sources */ = {isa = PBXBuildFile; fileRef = BEA2779828DE8D1A00511D9E /* Downloads */; };
-		BEC2861128ECD0D1008DAE2A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BEC2861028ECD0D1008DAE2A /* GoogleService-Info.plist */; };
-		BEC2861328ECD0DA008DAE2A /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC2861228ECD0DA008DAE2A /* Secrets.swift */; };
 		F07EDD8C25C626FE0097C813 /* GroupMembersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07EDD8B25C626FE0097C813 /* GroupMembersView.swift */; };
 		F0E4A47C25BCEC3000FF2256 /* StudyGroupDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E4A47B25BCEC3000FF2256 /* StudyGroupDetailsViewController.swift */; };
 		FD3D6FFF25C2BB7D00579EF5 /* SelectPeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3D6FFE25C2BB7D00579EF5 /* SelectPeopleView.swift */; };
@@ -388,10 +388,10 @@
 		55DCF79C237243F5001B01B8 /* RippleLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RippleLayer.swift; sourceTree = "<group>"; };
 		55DCF7A023724835001B01B8 /* MaterialButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterialButton.swift; sourceTree = "<group>"; };
 		61110ED9482F3D5A5CFFE6B9 /* Pods-berkeley-mobile.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-berkeley-mobile.release.xcconfig"; path = "Target Support Files/Pods-berkeley-mobile/Pods-berkeley-mobile.release.xcconfig"; sourceTree = "<group>"; };
+		BE18B9A228F0FC2500FF72A9 /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
+		BE18B9A428F0FC2D00FF72A9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BEA2779628DE8D1100511D9E /* .. */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = ..; path = ../..; sourceTree = "<group>"; };
 		BEA2779828DE8D1A00511D9E /* Downloads */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = Downloads; path = ../../../Downloads; sourceTree = "<group>"; };
-		BEC2861028ECD0D1008DAE2A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		BEC2861228ECD0DA008DAE2A /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Secrets.swift; path = ../../../Downloads/Secrets.swift; sourceTree = "<group>"; };
 		F07EDD8B25C626FE0097C813 /* GroupMembersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupMembersView.swift; sourceTree = "<group>"; };
 		F0E4A47B25BCEC3000FF2256 /* StudyGroupDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyGroupDetailsViewController.swift; sourceTree = "<group>"; };
 		F9CAC9CEE1078D95B189B835 /* Pods_berkeley_mobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_berkeley_mobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -929,8 +929,8 @@
 				306A54F223613E3D00D59A7F /* Assets.xcassets */,
 				306A54F423613E3D00D59A7F /* LaunchScreen.storyboard */,
 				306A54F723613E3D00D59A7F /* Info.plist */,
-				BEC2861028ECD0D1008DAE2A /* GoogleService-Info.plist */,
-				BEC2861228ECD0DA008DAE2A /* Secrets.swift */,
+				BE18B9A228F0FC2500FF72A9 /* Secrets.swift */,
+				BE18B9A428F0FC2D00FF72A9 /* GoogleService-Info.plist */,
 				BEA2779828DE8D1A00511D9E /* Downloads */,
 				BEA2779628DE8D1100511D9E /* .. */,
 			);
@@ -1117,7 +1117,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BEC2861128ECD0D1008DAE2A /* GoogleService-Info.plist in Resources */,
+				BE18B9A528F0FC2D00FF72A9 /* GoogleService-Info.plist in Resources */,
 				BEA2779728DE8D1100511D9E /* .. in Resources */,
 				01D269952544D86C000377B4 /* Apercu Light Italic.otf in Resources */,
 				306A54F623613E3D00D59A7F /* LaunchScreen.storyboard in Resources */,
@@ -1200,7 +1200,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				130FA59F243B12B3005DC752 /* Resource.swift in Sources */,
-				BEC2861328ECD0DA008DAE2A /* Secrets.swift in Sources */,
+				BE18B9A328F0FC2500FF72A9 /* Secrets.swift in Sources */,
 				BEA2779928DE8D1B00511D9E /* Downloads in Sources */,
 				13B8E9592425819D00E7FCBF /* ResourceDataSource.swift in Sources */,
 				01FA50F324E8BA5400DCC490 /* LocationDetailView.swift in Sources */,

--- a/berkeley-mobile/StudyPact/Profile/ProfileViewController.swift
+++ b/berkeley-mobile/StudyPact/Profile/ProfileViewController.swift
@@ -35,7 +35,9 @@ class ProfileViewController: UIViewController, UITextFieldDelegate, UINavigation
     private var fullNameField: BorderedTextField!
     private var emailTextField: TaggedTextField!
     private var facebookTextField: TaggedTextField!
-    private var phoneTextField: BorderedTextField!
+    //chage private var phoneTextField: BorderedTextField!
+    private var phoneTextField: TaggedTextField!
+    
     
     private var changeImageButton: UIButton!
     private var imagePicker: UIImagePickerController!
@@ -441,18 +443,19 @@ extension ProfileViewController {
         phoneLabel.setHeightConstraint(36)
         phoneLabel.leftAnchor.constraint(equalTo: rows.leftAnchor).isActive = true
         
-        let phoneField = BorderedTextField()
-        phoneField.delegate = self
-        phoneField.keyboardType = .phonePad
+        let phoneField = TaggedTextField(tagText: "ex. 1234567890")
+        phoneField.textField.delegate = self
+        phoneField.textField.autocorrectionType = .no
+        phoneField.textField.keyboardType = .URL
+        phoneField.textField.textColor = Color.blackText
         
         phoneRow.addArrangedSubview(phoneField)
 
         phoneField.translatesAutoresizingMaskIntoConstraints = false
-        phoneField.setHeightConstraint(36)
+        phoneField.setHeightConstraint(50)
         phoneField.rightAnchor.constraint(equalTo: rows.rightAnchor).isActive = true
 
-        phoneTextField = phoneField
-
+        
         // ** FACEBOOK SECTION ** //
         let fbRow = UIStackView()
         fbRow.axis = .horizontal
@@ -493,6 +496,7 @@ extension ProfileViewController {
         fullNameField = firstnameField
         emailTextField = emailField
         facebookTextField = facebookField
+        phoneTextField = phoneField
         
         // ** BUTTONS ** //
         let cancelButton = ActionButton(title: "Cancel", font: Font.bold(14), defaultColor: Color.StudyPact.StudyGroups.leaveGroupButton, pressedColor: Color.StudyPact.StudyGroups.leaveGroupButton)
@@ -548,7 +552,7 @@ extension ProfileViewController {
     
     @objc private func cancelButtonPressed(sender: UIButton) {
         fullNameField.setDefault()
-        phoneTextField.setDefault()
+        phoneTextField.textField.setDefault()
         facebookTextField.textField.setDefault()
         
         // Get user info from backend
@@ -564,9 +568,9 @@ extension ProfileViewController {
         
         self.fullNameField.text = info["name"]
         if let phone = info["phone"] {
-            self.phoneTextField.text = phone
+            self.phoneTextField.textField.text = phone
         } else {
-            self.phoneTextField.text = ""
+            self.phoneTextField.textField.text = ""
         }
         if let fb = info["facebook"] {
             self.facebookTextField.textField.text = fb
@@ -591,7 +595,7 @@ extension ProfileViewController {
     @objc private func saveButtonPressed(sender: UIButton) {
         let name = fullNameField.text
         let facebook = validateFacebook(text: facebookTextField.textField.text ?? "")
-        let phoneNumber = validatePhoneNumber(text: phoneTextField.text ?? "")
+        let phoneNumber = validatePhoneNumber(text: phoneTextField.textField.text ?? "")
         
         var hasInvalid = false
         if name == "" {
@@ -602,15 +606,15 @@ extension ProfileViewController {
             hasInvalid = true
             facebookTextField.textField.setInvalid()
         }
-        if phoneTextField.text != "" && phoneNumber == nil {
+        if phoneTextField.textField.text != "" && phoneNumber == nil {
             hasInvalid = true
-            phoneTextField.setInvalid()
+            phoneTextField.textField.setInvalid()
         }
         if hasInvalid {
             return
         }
         fullNameField.setDefault()
-        phoneTextField.setDefault()
+        phoneTextField.textField.setDefault()
         facebookTextField.textField.setDefault()
         
         // Adds updated user

--- a/berkeley-mobile/StudyPact/Profile/ProfileViewController.swift
+++ b/berkeley-mobile/StudyPact/Profile/ProfileViewController.swift
@@ -37,7 +37,6 @@ class ProfileViewController: UIViewController, UITextFieldDelegate, UINavigation
     private var facebookTextField: TaggedTextField!
     private var phoneTextField: TaggedTextField!
     
-    
     private var changeImageButton: UIButton!
     private var imagePicker: UIImagePickerController!
     
@@ -445,7 +444,7 @@ extension ProfileViewController {
         let phoneField = TaggedTextField(tagText: "ex. 1234567890")
         phoneField.textField.delegate = self
         phoneField.textField.autocorrectionType = .no
-        phoneField.textField.keyboardType = .URL
+        phoneField.textField.keyboardType = .phonePad
         phoneField.textField.textColor = Color.blackText
         
         phoneRow.addArrangedSubview(phoneField)
@@ -453,6 +452,8 @@ extension ProfileViewController {
         phoneField.translatesAutoresizingMaskIntoConstraints = false
         phoneField.setHeightConstraint(50)
         phoneField.rightAnchor.constraint(equalTo: rows.rightAnchor).isActive = true
+        
+        phoneTextField = phoneField
 
         
         // ** FACEBOOK SECTION ** //
@@ -495,7 +496,6 @@ extension ProfileViewController {
         fullNameField = firstnameField
         emailTextField = emailField
         facebookTextField = facebookField
-        phoneTextField = phoneField
         
         // ** BUTTONS ** //
         let cancelButton = ActionButton(title: "Cancel", font: Font.bold(14), defaultColor: Color.StudyPact.StudyGroups.leaveGroupButton, pressedColor: Color.StudyPact.StudyGroups.leaveGroupButton)

--- a/berkeley-mobile/StudyPact/Profile/ProfileViewController.swift
+++ b/berkeley-mobile/StudyPact/Profile/ProfileViewController.swift
@@ -35,7 +35,6 @@ class ProfileViewController: UIViewController, UITextFieldDelegate, UINavigation
     private var fullNameField: BorderedTextField!
     private var emailTextField: TaggedTextField!
     private var facebookTextField: TaggedTextField!
-    //chage private var phoneTextField: BorderedTextField!
     private var phoneTextField: TaggedTextField!
     
     


### PR DESCRIPTION
- changed phoneTextField from a BorderedTextField to a TaggedTextField in order to add a description underneath the input box
- modified the corresponding code for phoneTextField based on the change
- added an example under the input box "ex. 1234567890" to specify for the users that the phone number can only consist of numbers