### PR TITLE
BER-33: [Events Tab]: UI/UX Improvements to Academic Events Calendar

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -1332,7 +1332,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "berkeley-mobile/berkeley-mobile.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 4HBETBULVA;
 				INFOPLIST_FILE = "berkeley-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -1356,7 +1356,7 @@
 				CODE_SIGN_ENTITLEMENTS = "berkeley-mobile/berkeley-mobile.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 4HBETBULVA;
 				INFOPLIST_FILE = "berkeley-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;

--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -1340,7 +1340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 10.3.3;
+				MARKETING_VERSION = 10.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = org.asuc.ASUC;
 				PRODUCT_NAME = Berkeley;
 				SWIFT_VERSION = 5.0;
@@ -1364,7 +1364,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 10.3.3;
+				MARKETING_VERSION = 10.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = org.asuc.ASUC;
 				PRODUCT_NAME = Berkeley;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/berkeley-mobile/Common/Calendar/CalendarTablePairView.swift
+++ b/berkeley-mobile/Common/Calendar/CalendarTablePairView.swift
@@ -85,6 +85,7 @@ class CalendarTablePairView: UIView {
         } else {
             showCalendarTable()
             calendarTable.reloadData()
+            calendarTableScrollToToday()
         }
     }
     
@@ -96,6 +97,11 @@ class CalendarTablePairView: UIView {
     private func hideCalendarTable() {
         missingDataView.isHidden = false
         missingDataView.isHidden = true
+    }
+    
+    private func calendarTableScrollToToday() {
+        let todayDay = Date().get(.day)
+        didSelectDay(day: todayDay)
     }
 }
 
@@ -147,5 +153,12 @@ extension CalendarTablePairView: CalendarViewDelegate {
             calendarTableHeightConstraint?.constant = min(calendarTable.contentSize.height, self.frame.height * 0.7)
         }
         self.layoutIfNeeded()
+    }
+    
+    func didSelectDay(day: Int) {
+        guard let tableEntryIndex = tableEntries.firstIndex(where: { $0.date.get(.day) == day }) else {
+            return
+        }
+        calendarTable.scrollToRow(at: IndexPath(row: tableEntryIndex, section: 0), at: .top, animated: true)
     }
 }

--- a/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
+++ b/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
@@ -61,20 +61,21 @@ extension CalendarEvent {
         get {
             var dateString = ""
             
-            // Check if to see if event is an "All Day" event
-            if date.doesDateComponentsAreEqualTo(hour: 0, minute: 0, sec: 0), let end,
-                end.doesDateComponentsAreEqualTo(hour: 11, minute: 59, sec: 59) {
-                return "All Day"
-            }
-            
             if date.dateOnly() == Date().dateOnly() {
-                dateString += "Today / "
+                dateString += "Today"
             } else if Date.isDateTomorrow(baseDate: Date(), date: date) {
-                dateString += "Tomorrow / "
+                dateString += "Tomorrow"
             } else {
                 let dateFormatter = DateFormatter()
                 dateFormatter.dateFormat = "MM/dd/yyyy"
-                dateString += dateFormatter.string(from: date) + " / "
+                dateString += dateFormatter.string(from: date)
+            }
+            dateString += " / "
+            
+            // Check if to see if event is an "All Day" event
+            if date.doesDateComponentsAreEqualTo(hour: 0, minute: 0, sec: 0), let end,
+                end.doesDateComponentsAreEqualTo(hour: 11, minute: 59, sec: 59) {
+                return dateString + "All Day"
             }
             
             let timeFormatter = DateFormatter()

--- a/berkeley-mobile/Utils/Date+Extension.swift
+++ b/berkeley-mobile/Utils/Date+Extension.swift
@@ -133,4 +133,8 @@ extension Date {
         return self > oneWeekAgo && self <= now
     }
     
+    /// Get integer representation of a calendar component from date
+    func get(_ component: Calendar.Component, calendar: Calendar = Calendar.current) -> Int {
+        return calendar.component(component, from: self)
+    }
 }


### PR DESCRIPTION
Linear: https://linear.app/moon-stone/issue/BER-33/[events-tab]-uiux-improvements-to-academic-events 

- Scroll to today's Academic Events upon first load
- Tapping on valid dates on the calendar view should scroll to the appropriate events section in the table view 
- Tapping on valid UICollectionViewCell shows expand and shrink animation
- Add mm/dd/yyyy to "All Day" verbiage

https://github.com/user-attachments/assets/952fe9a5-6d29-4d12-9677-0c665a3f3409

