### PR TITLE
BER-47: Remove Home Tab Map Markers Scroll View

### DIFF
--- a/berkeley-mobile/Map/MapMarkersDropdownView.swift
+++ b/berkeley-mobile/Map/MapMarkersDropdownView.swift
@@ -8,19 +8,34 @@
 
 import SwiftUI
 
+class MapMarkersDropdownViewModel: ObservableObject {
+    @Published var selectedFilterIndex = 0
+    @Published var mapMarkerTypes = MapMarkerType.allCases
+    
+    func sortMapMarkerTypes(basedOn filters: [Filter<[MapMarker]>]) {
+        let filterLabels = filters.map { $0.label }
+        mapMarkerTypes = filterLabels.compactMap { MapMarkerType(rawValue: $0) }
+    }
+}
+
 struct MapMarkersDropdownButton: View {
+    @EnvironmentObject var viewModel: MapMarkersDropdownViewModel
     @State private var isPresentingMapMarkersDropdownView = false
-    var selectedMapMakerTypeCompletionHandler: (MapMarkerType) -> Void
+
+    var selectedMapMakerTypeCompletionHandler: () -> Void
     
     var body: some View {
         Button(action: {
             isPresentingMapMarkersDropdownView.toggle()
         }) {
-            Image(systemName: "chevron.down.circle")
-                .background(Color(uiColor: BMColor.modalBackground))
-                .foregroundColor(Color(uiColor: BMColor.blackText))
+            Circle()
+                .fill(Color(uiColor: BMColor.modalBackground))
+                .frame(width: 50, height: 50)
                 .font(.system(size: 42))
                 .clipShape(Circle())
+                .overlay(
+                    Image(uiImage: viewModel.mapMarkerTypes[viewModel.selectedFilterIndex].icon())
+                )
         }
         .fullScreenCover(isPresented: $isPresentingMapMarkersDropdownView) {
             MapMarkersDropdownView(selectedMapMakerTypeCompletionHandler: selectedMapMakerTypeCompletionHandler)
@@ -30,30 +45,37 @@ struct MapMarkersDropdownButton: View {
     }
 }
 
-//MARK: - MapMarkersDropdownView
+
+// MARK: - MapMarkersDropdownView
+
 struct MapMarkersDropdownView: View {
+    @EnvironmentObject var viewModel: MapMarkersDropdownViewModel
     @Environment(\.dismiss) private var dismiss
-    private let mapMarkerTypes = MapMarkerType.allCases.sorted(by: { $0.rawValue < $1.rawValue })
-    var selectedMapMakerTypeCompletionHandler: (MapMarkerType) -> Void
+  
+    var selectedMapMakerTypeCompletionHandler: () -> Void
     
     var body: some View {
         ZStack {
-            List(mapMarkerTypes, id: \.self) { type in
-                if type != MapMarkerType.none {
-                    HStack(spacing: 15){
+            List(Array(viewModel.mapMarkerTypes.enumerated()), id: \.offset) { index, type in
+                Button(action: {
+                    viewModel.selectedFilterIndex = index
+                    selectedMapMakerTypeCompletionHandler()
+                    dismiss()
+                }) {
+                    HStack(spacing: 15) {
                         Image(uiImage: type.icon())
                         Text(type.rawValue)
                             .fontWeight(.semibold)
-                            .font(.title3)
+                            .font(.system(size: 19))
+                            .foregroundStyle(.primary)
+                        Spacer()
                     }
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
-                    .frame(height: 40)
-                    .onTapGesture {
-                        selectedMapMakerTypeCompletionHandler(type)
-                        dismiss()
-                    }
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+                .frame(height: 40)
             }
             .padding(EdgeInsets(top: 20, leading: 0, bottom: 0, trailing: 0))
             .scrollIndicators(.hidden)
@@ -82,7 +104,9 @@ struct MapMarkersDropdownView: View {
     }
 }
 
-//MARK: - BMBackgroundBlurView
+
+// MARK: - BMBackgroundBlurView
+
 struct BMBackgroundBlurView: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let view = UIVisualEffectView(effect: UIBlurEffect(style: .light))
@@ -97,9 +121,9 @@ struct BMBackgroundBlurView: UIViewRepresentable {
 
 
 #Preview("MapMarkersDropdownView") {
-    MapMarkersDropdownView(selectedMapMakerTypeCompletionHandler: {_ in})
+    MapMarkersDropdownView(selectedMapMakerTypeCompletionHandler: { })
 }
 
 #Preview("MapMarkersDropdownButton") {
-    MapMarkersDropdownButton(selectedMapMakerTypeCompletionHandler: {_ in})
+    MapMarkersDropdownButton(selectedMapMakerTypeCompletionHandler: { })
 }

--- a/berkeley-mobile/Map/MapMarkersDropdownView.swift
+++ b/berkeley-mobile/Map/MapMarkersDropdownView.swift
@@ -24,15 +24,16 @@ struct MapMarkersDropdownButton: View {
 
     var selectedMapMakerTypeCompletionHandler: () -> Void
     
+    private let widthAndHeight: CGFloat = 50
+    
     var body: some View {
         Button(action: {
             isPresentingMapMarkersDropdownView.toggle()
         }) {
             Circle()
-                .fill(Color(uiColor: BMColor.modalBackground))
-                .frame(width: 50, height: 50)
-                .font(.system(size: 42))
-                .clipShape(Circle())
+                .strokeBorder(.gray, lineWidth: 0.5)
+                .background(Circle().fill(.regularMaterial))
+                .frame(width: widthAndHeight, height: widthAndHeight)
                 .overlay(
                     Image(uiImage: viewModel.mapMarkerTypes[viewModel.selectedFilterIndex].icon())
                 )
@@ -41,7 +42,6 @@ struct MapMarkersDropdownButton: View {
             MapMarkersDropdownView(selectedMapMakerTypeCompletionHandler: selectedMapMakerTypeCompletionHandler)
                 .background(BMBackgroundBlurView().ignoresSafeArea(.all))
         }
-        .shadow(color: Color(uiColor: UIColor.black).opacity(0.2), radius: 5, x: 0, y: 5)
     }
 }
 
@@ -122,8 +122,10 @@ struct BMBackgroundBlurView: UIViewRepresentable {
 
 #Preview("MapMarkersDropdownView") {
     MapMarkersDropdownView(selectedMapMakerTypeCompletionHandler: { })
+        .environmentObject(MapMarkersDropdownViewModel())
 }
 
 #Preview("MapMarkersDropdownButton") {
     MapMarkersDropdownButton(selectedMapMakerTypeCompletionHandler: { })
+        .environmentObject(MapMarkersDropdownViewModel())
 }


### PR DESCRIPTION
- Removed map markers scroll view
- Upon app launch, selects the first map marker type and populate the map
- MapMarkersDropdownView button shows selected map marker type icon
- Added ability in MapMarkersDropdownView to select marker type by clicking on "empty area" of the row 

https://github.com/user-attachments/assets/47700bc3-f030-45ca-8124-b7a3f461b47c

