### PR TITLE
BER-55: Update Gitignore For Secrets and GoogleInfoService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,8 @@ xcuserdata/
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint
-GoogleService-Info.plist
-Secrets.swift
+berkeley-mobile/GoogleService-Info.plist
+berkeley-mobile/Secrets.swift
 
 ## Cocoapods
 ##Pods/


### PR DESCRIPTION
Fix paths for Secrets and GoogleInfoService.plist. Need to add relative path not just the file names.