### PR TITLE
BER-49: Improve SegmentedControlView's Indicator Bar

### DIFF
--- a/berkeley-mobile/Common/SegmentedControl/SegmentedControlView.swift
+++ b/berkeley-mobile/Common/SegmentedControl/SegmentedControlView.swift
@@ -13,8 +13,8 @@ struct SegmentedControlView: View {
     private struct Constants {
         static let tabSpacing: CGFloat = 20
         static let textSize: CGFloat = 18
-        static let indicatorOffset: CGFloat = -28
-        static let indicatorHeight: CGFloat = 13
+        static let indicatorOffset: CGFloat = 1
+        static let indicatorHeight: CGFloat = 8
     }
     
     var tabNames: [String]
@@ -31,15 +31,15 @@ struct SegmentedControlView: View {
                     }
                 }) {
                     VStack(spacing: Constants.indicatorOffset) {
+                        Text(tabName)
+                            .foregroundStyle(Color(uiColor: selectedTabIndex == index ? BMColor.primaryText : BMColor.secondaryText))
+                            .font(Font(BMFont.bold(Constants.textSize)))
+                        
                         if selectedTabIndex == index {
                             capsule
                         } else {
                             placeholderCapsule
                         }
-                        
-                        Text(tabName)
-                            .foregroundStyle(Color(uiColor: selectedTabIndex == index ? BMColor.primaryText : BMColor.secondaryText))
-                            .font(Font(BMFont.bold(Constants.textSize)))
                     }
                 }
             }


### PR DESCRIPTION
- Moved the indicator down and changed its height (thickness) so it didn't occlude with the tab names
- Experimented with the numbers for height and spacing.
   - weird behavior happened for indicatorOffset of -30 and indicatorHeight of 8: the tabs were not tappable in the preview (exaclty for these numbers);
   - and for some other numbers the tabs would only be tapped and selected if tapped on the center of the text (tab name) and not the edges
- Small refactoring helped to make the tapping behavior more deterministic
   - reordered the `Text` and `capsule` views in the hierarchy and adjusted the numbers

<div align="center">
<img width="300" alt="Screenshot 2025-02-21 at 12 15 41 PM" src="https://github.com/user-attachments/assets/c4e53b9e-c973-4c8f-8fe8-3300f12b3bc6" />
</div>

