### PR TITLE
BER-62: Recreate FilterTableViewCell in SwiftUI

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		29CB280A2404DD71009A2CFB /* FilterTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B39AA423E774600039FBA2 /* FilterTableViewCell.swift */; };
 		29EE163F241C4E310041482E /* SortingFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EE163E241C4E310041482E /* SortingFunctions.swift */; };
 		29F11EC72516C150007DCFD7 /* BarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F11EC62516C150007DCFD7 /* BarView.swift */; };
+		2EC1656A2D752A7300F88B60 /* HomeSectionListRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC165692D752A7300F88B60 /* HomeSectionListRowView.swift */; };
 		303F6AE1236A931D007E37DD /* SegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303F6ADD236A931D007E37DD /* SegmentedControl.swift */; };
 		303F6AE4236A931D007E37DD /* SegmentedControlViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303F6AE0236A931D007E37DD /* SegmentedControlViewController.swift */; };
 		306A54EA23613E3A00D59A7F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306A54E923613E3A00D59A7F /* AppDelegate.swift */; };
@@ -302,6 +303,7 @@
 		29B3D78724539FF3006762E5 /* MainDrawerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDrawerViewController.swift; sourceTree = "<group>"; };
 		29EE163E241C4E310041482E /* SortingFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortingFunctions.swift; sourceTree = "<group>"; };
 		29F11EC62516C150007DCFD7 /* BarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarView.swift; sourceTree = "<group>"; };
+		2EC165692D752A7300F88B60 /* HomeSectionListRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSectionListRowView.swift; sourceTree = "<group>"; };
 		303F6ADD236A931D007E37DD /* SegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControl.swift; sourceTree = "<group>"; };
 		303F6AE0236A931D007E37DD /* SegmentedControlViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControlViewController.swift; sourceTree = "<group>"; };
 		306A54E623613E3A00D59A7F /* Berkeley.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Berkeley.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -733,6 +735,7 @@
 			children = (
 				29AB5BC4241D8CB4007C3ECA /* FilterTableView.swift */,
 				13B39AA423E774600039FBA2 /* FilterTableViewCell.swift */,
+				2EC165692D752A7300F88B60 /* HomeSectionListRowView.swift */,
 			);
 			path = FilterTableView;
 			sourceTree = "<group>";
@@ -1117,6 +1120,7 @@
 				13491DB8241E22130033F9AB /* Colors+Event.swift in Sources */,
 				13B39A9923E6A33C0039FBA2 /* Library.swift in Sources */,
 				303F6AE4236A931D007E37DD /* SegmentedControlViewController.swift in Sources */,
+				2EC1656A2D752A7300F88B60 /* HomeSectionListRowView.swift in Sources */,
 				559A7B6F2373DF39004EA501 /* SearchResultCell.swift in Sources */,
 				299ACFB0244A58CD000F3E86 /* OccupancyDataSource.swift in Sources */,
 				29345E2B24A7EC2B00859A88 /* HasImage.swift in Sources */,

--- a/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
+++ b/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
@@ -12,35 +12,19 @@ struct HomeSectionListRowView: View {
     var title: String
     var distance: Double
     var image: UIImage
-    
     var body: some View {
         HStack {
             VStack (alignment: .leading) {
                 Text(title)
                     .foregroundStyle(Color(BMColor.blackText))
                     .font(Font(BMFont.bold(18)))
-                
                 Spacer()
-                
-                HStack {
-                    Image(systemName: "figure.walk")
-                        .foregroundStyle(Color(BMColor.blackText))
-                        .font(.system(size: 16))
-                    
-                    Text("\(distance, specifier: "%.1f") mi")
-                        .foregroundStyle(Color(BMColor.blackText))
-                        .font(Font(BMFont.regular(16)))
-                }
+                distanceLabelView
             }
             .frame(height: 74)
             
             Spacer()
-            
-            Image(uiImage: image)
-                .resizable()
-                .scaledToFill()
-                .frame(width: 80, height: 80)
-                .clipShape(.rect(cornerRadius: 12))
+            imageView
         }
         .padding(.horizontal, 16)
         .frame(maxWidth: .infinity)
@@ -49,13 +33,30 @@ struct HomeSectionListRowView: View {
         .clipShape(.rect(cornerRadius: 12))
         .shadow(color: .black.opacity(0.25), radius: 5)
     }
+    
+    private var distanceLabelView: some View {
+        HStack {
+            Image(systemName: "figure.walk")
+                .foregroundStyle(Color(BMColor.blackText))
+                .font(.system(size: 16))
+            
+            Text("\(distance, specifier: "%.1f") mi")
+                .foregroundStyle(Color(BMColor.blackText))
+                .font(Font(BMFont.regular(16)))
+        }
+    }
+    
+    private var imageView: some View {
+        Image(uiImage: image)
+            .resizable()
+            .scaledToFill()
+            .frame(width: 80, height: 80)
+            .clipShape(.rect(cornerRadius: 12))
+    }
 }
 
-
 #Preview {
-    let defaultImage = UIImage(named: "DoeGlade")
-    if let defaultImage {
-        HomeSectionListRowView(title: "Albany Bulb", distance: 8.4, image: defaultImage)
-            .padding(40)
-    }
+    let defaultImage = UIImage(named: "DoeGlade")!
+    HomeSectionListRowView(title: "Albany Bulb", distance: 8.4, image: defaultImage)
+        .padding(40)
 }

--- a/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
+++ b/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
@@ -25,6 +25,7 @@ struct HomeSectionListRowView: View {
             .frame(height: 74)
             
             Spacer()
+            
             imageView
         }
         .padding(.horizontal, 16)

--- a/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
+++ b/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
@@ -1,0 +1,59 @@
+//
+//  HomeSectionListRowView.swift
+//  berkeley-mobile
+//
+//  Created by Baurzhan on 3/2/25.
+//  Copyright © 2025 ASUC OCTO. All rights reserved.
+//
+
+import SwiftUI
+
+struct HomeSectionListRowView: View {
+    var title: String
+    var distance: Double
+    var image: UIImage
+    
+    var body: some View {
+        HStack {
+            VStack (alignment: .leading, spacing: 30) {
+                Text(title)
+                    .foregroundStyle(Color(BMColor.blackText))
+                    .font(Font(BMFont.bold(18)))
+                    .lineLimit(1)
+                
+                HStack {
+                    Image(systemName: "figure.walk")
+                        .foregroundStyle(Color(BMColor.blackText))
+                        .font(.headline)
+                    
+                    Text("\(distance, specifier: "%.1f") mi")
+                        .foregroundStyle(Color(BMColor.blackText))
+                        .font(Font(BMFont.regular(16)))
+                }
+            }
+            
+            Spacer()
+            
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 80, height: 80)
+                .clipShape(.rect(cornerRadius: 12))
+        }
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity)
+        .frame(height: 100)
+        .background(Color(BMColor.modalBackground))
+        .clipShape(.rect(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.25), radius: 5)
+    }
+}
+
+
+#Preview {
+    let defaultImage = UIImage(named: "DoeGlade")
+    if let defaultImage {
+        HomeSectionListRowView(title: "Albany Bulb", distance: 8.4, image: defaultImage)
+            .padding(40)
+    }
+}

--- a/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
+++ b/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
@@ -15,22 +15,24 @@ struct HomeSectionListRowView: View {
     
     var body: some View {
         HStack {
-            VStack (alignment: .leading, spacing: 30) {
+            VStack (alignment: .leading) {
                 Text(title)
                     .foregroundStyle(Color(BMColor.blackText))
                     .font(Font(BMFont.bold(18)))
-                    .lineLimit(1)
+                
+                Spacer()
                 
                 HStack {
                     Image(systemName: "figure.walk")
                         .foregroundStyle(Color(BMColor.blackText))
-                        .font(.headline)
+                        .font(.system(size: 16))
                     
                     Text("\(distance, specifier: "%.1f") mi")
                         .foregroundStyle(Color(BMColor.blackText))
                         .font(Font(BMFont.regular(16)))
                 }
             }
+            .frame(height: 74)
             
             Spacer()
             

--- a/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
+++ b/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
@@ -12,9 +12,10 @@ struct HomeSectionListRowView: View {
     var title: String
     var distance: Double
     var image: UIImage
+    
     var body: some View {
         HStack {
-            VStack (alignment: .leading) {
+            VStack(alignment: .leading) {
                 Text(title)
                     .foregroundStyle(Color(BMColor.blackText))
                     .font(Font(BMFont.bold(18)))

--- a/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
+++ b/berkeley-mobile/Common/FilterTableView/HomeSectionListRowView.swift
@@ -28,7 +28,6 @@ struct HomeSectionListRowView: View {
             imageView
         }
         .padding(.horizontal, 16)
-        .frame(maxWidth: .infinity)
         .frame(height: 100)
         .background(Color(BMColor.modalBackground))
         .clipShape(.rect(cornerRadius: 12))


### PR DESCRIPTION
- recreated FilterTableViewCell in SwiftUI
- matched fonts and frame sizes approximately to the UIKit version (though cell height is a little bigger to improve padding around the image)
- added rounded corners to the image

<div align="center">
<img width="500" alt="Screenshot 2025-03-03 at 2 44 57 PM" src="https://github.com/user-attachments/assets/fc078272-70f4-4d71-985c-7d46b545b50f" />
</div>