### PR TITLE
BER-78: Replace Home Drawer Section Table Cells With HomeSectionListRowView

### DIFF
--- a/berkeley-mobile/Dining/DiningViewController.swift
+++ b/berkeley-mobile/Dining/DiningViewController.swift
@@ -80,7 +80,7 @@ class DiningViewController: UIViewController, SearchDrawerViewDelegate {
             object: nil
         )
         
-        // fetch dining hall and cafe data, make sure occupancy data has been fetched after each one is complete
+        // Fetch dining hall and cafe data, make sure occupancy data has been fetched after each one is complete
         DataManager.shared.fetch(source: DiningHallDataSource.self) { diningLocations in
             self.diningLocations.append(contentsOf: diningLocations as? [DiningLocation] ?? [])
             self.filterTableView.setData(data: self.diningLocations)
@@ -99,13 +99,17 @@ class DiningViewController: UIViewController, SearchDrawerViewDelegate {
 
 extension DiningViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if let cell = tableView.dequeueReusableCell(withIdentifier: FilterTableViewCell.kCellIdentifier, for: indexPath) as? FilterTableViewCell {
-            if let diningHall: DiningLocation = self.filterTableView.filteredData[safe: indexPath.row] {
-                cell.updateContents(item: diningHall)
-                return cell
-            }
+        let cell = tableView.dequeueReusableCell(withIdentifier: FilterTableViewCell.kCellIdentifier, for: indexPath)
+        let diningHall = self.filterTableView.filteredData[indexPath.row]
+        
+        let cellViewModel = HomeSectionListRowViewModel()
+        cellViewModel.configureRow(with: diningHall)
+        
+        cell.contentConfiguration = UIHostingConfiguration {
+            HomeSectionListRowView()
+                .environmentObject(cellViewModel)
         }
-        return UITableViewCell()
+        return cell
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -122,7 +126,6 @@ extension DiningViewController: UITableViewDelegate, UITableViewDataSource {
 // MARK: View
 
 extension DiningViewController {
-    // General card page
     func setupCardView() {
         let card = CardView()
         card.layoutMargins = UIEdgeInsets(top: 20, left: 16, bottom: 16, right: 16)
@@ -164,7 +167,6 @@ extension DiningViewController {
         headerLabel = header
     }
     
-    // Table of dining locations
     func setupTableView() {
         let functions: [TableFunction] = [
             Sort<DiningLocation>(label: "Nearby", sort: DiningHall.locationComparator()),

--- a/berkeley-mobile/Fitness/Fitness+Controllers/GymsController.swift
+++ b/berkeley-mobile/Fitness/Fitness+Controllers/GymsController.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import SwiftUI
 
 /**
     Helper to handle Data Source protocols for collections with Gyms.
@@ -32,13 +33,17 @@ extension GymsController: UITableViewDataSource, UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if let cell = tableView.dequeueReusableCell(withIdentifier: FilterTableViewCell.kCellIdentifier, for: indexPath) as? FilterTableViewCell {
-            if let gym: Gym = vc.filterTableView.filteredData[safe: indexPath.row] {
-                cell.updateContents(item: gym)
-                return cell
-            }
+        let cell = tableView.dequeueReusableCell(withIdentifier: FilterTableViewCell.kCellIdentifier, for: indexPath)
+        let gym = vc.filterTableView.filteredData[indexPath.row]
+        
+        let cellViewModel = HomeSectionListRowViewModel()
+        cellViewModel.configureRow(with: gym)
+        
+        cell.contentConfiguration = UIHostingConfiguration {
+            HomeSectionListRowView()
+                .environmentObject(cellViewModel)
         }
-        return UITableViewCell()
+        return cell
     }
     
 }

--- a/berkeley-mobile/Fitness/FitnessViewController.swift
+++ b/berkeley-mobile/Fitness/FitnessViewController.swift
@@ -46,6 +46,7 @@ class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
     var initialDrawerCenter = CGPoint()
     var initialGestureTranslation: CGPoint = CGPoint()
     var drawerStatePositions: [DrawerState : CGFloat] = [:]
+    
     // SearchDrawerViewDelegate property
     var mainContainer: MainContainerViewController?
     var pinDelegate: SearchResultsViewDelegate?
@@ -96,7 +97,7 @@ class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
         
         gymsController.vc = self
         
-        // fetch gyms and fetch occupancy data afterwards
+        // Fetch gyms and fetch occupancy data afterwards
         DataManager.shared.fetch(source: GymDataSource.self) { gyms in
             self.gyms = gyms as? [Gym] ?? []
             self.filterTableView.setData(data: gyms as! [Gym])

--- a/berkeley-mobile/Libraries/StudyViewController.swift
+++ b/berkeley-mobile/Libraries/StudyViewController.swift
@@ -183,12 +183,16 @@ class StudyViewController: UIViewController, UITableViewDataSource, UITableViewD
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if let cell = tableView.dequeueReusableCell(withIdentifier: FilterTableViewCell.kCellIdentifier, for: indexPath) as? FilterTableViewCell {
-            if let lib: Library = self.filterTableView.filteredData[safe: indexPath.row] {
-                cell.updateContents(item: lib)
-                return cell
-            }
+        let cell = tableView.dequeueReusableCell(withIdentifier: FilterTableViewCell.kCellIdentifier, for: indexPath)
+        let library = self.filterTableView.filteredData[indexPath.row]
+        
+        let cellViewModel = HomeSectionListRowViewModel()
+        cellViewModel.configureRow(with: library)
+        
+        cell.contentConfiguration = UIHostingConfiguration {
+            HomeSectionListRowView()
+                .environmentObject(cellViewModel)
         }
-        return UITableViewCell()
+        return cell
     }
 }


### PR DESCRIPTION
- In `DiningViewController`, `GymsController`, and `FitnessViewController`, replace the table view cells with `HomeSectionListRowView` via the table view cell's `cellConfiguration` and `UIHostingConfiguration`. 
- Update `HomeSectionListRowView` to work with table view cell's `cellConfiguration`
- Create `HomeSectionListRowViewModel` to drive data to `HomeSectionListRowView` in table view's `cellForRowAt` delegate method

https://github.com/user-attachments/assets/6466cd28-fd61-4d8a-8561-72b42120b755

