### PR TITLE
BER-72: Rewrite CardView in SwiftUI as a View Modifier

### DIFF
--- a/berkeley-mobile/Utils/View+Extension.swift
+++ b/berkeley-mobile/Utils/View+Extension.swift
@@ -30,7 +30,7 @@ struct HomeMapControlButtonStyle: ButtonStyle {
 struct Cardify: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .padding()
+            .padding(3)
             .background(
                 RoundedRectangle(cornerRadius: 12)
                     .fill(Color(BMColor.cardBackground)) 

--- a/berkeley-mobile/Utils/View+Extension.swift
+++ b/berkeley-mobile/Utils/View+Extension.swift
@@ -25,3 +25,22 @@ struct HomeMapControlButtonStyle: ButtonStyle {
             )
     }
 }
+
+
+struct Cardify: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(BMColor.cardBackground)) 
+            )
+            .shadow(color: Color.black.opacity(0.25), radius: 5, x: 0, y: 0)
+    }
+}
+
+extension View {
+    func cardify() -> some View {
+        self.modifier(Cardify())
+    }
+}


### PR DESCRIPTION
ticket: https://linear.app/moon-stone/issue/BER-72/rewrite-cardview-in-swiftui-as-a-view-modifier
I've written the view modifier for Cardify in View+Extension.swift and test it.


<img width="230" alt="cardify test" src="https://github.com/user-attachments/assets/53134cec-32dd-4da4-a7b4-32204c99d8b5" />
