### PR TITLE
BER-60: New Safety View Maps UI with Custom Annotations

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		E83D87942AB3CD1E00C4113C /* FeedbackFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83D87932AB3CD1E00C4113C /* FeedbackFormView.swift */; };
 		E86F59232B9BA85700907251 /* StudyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86F59222B9BA85700907251 /* StudyViewController.swift */; };
 		E8912BE52D7FE40500C645B9 /* SafetyMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8912BE42D7FE40500C645B9 /* SafetyMapView.swift */; };
+		E8912C2A2D869D6900C645B9 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8912C292D869D6900C645B9 /* Constants.swift */; };
 		E8B2738D2BD5C83F0009831A /* SafetyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B2738C2BD5C83F0009831A /* SafetyView.swift */; };
 		E8B2738F2BD5E46B0009831A /* BMDrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B2738E2BD5E46B0009831A /* BMDrawerView.swift */; };
 		E8B273912BD5E5770009831A /* SafetyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B273902BD5E5770009831A /* SafetyViewModel.swift */; };
@@ -362,6 +363,7 @@
 		E83D87932AB3CD1E00C4113C /* FeedbackFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackFormView.swift; sourceTree = "<group>"; };
 		E86F59222B9BA85700907251 /* StudyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyViewController.swift; sourceTree = "<group>"; };
 		E8912BE42D7FE40500C645B9 /* SafetyMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyMapView.swift; sourceTree = "<group>"; };
+		E8912C292D869D6900C645B9 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		E8B2738C2BD5C83F0009831A /* SafetyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyView.swift; sourceTree = "<group>"; };
 		E8B2738E2BD5E46B0009831A /* BMDrawerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BMDrawerView.swift; sourceTree = "<group>"; };
 		E8B273902BD5E5770009831A /* SafetyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyViewModel.swift; sourceTree = "<group>"; };
@@ -821,6 +823,7 @@
 				55DCF78523722CAE001B01B8 /* Assets */,
 				016A56D7251C930D00531A12 /* AppDelegate+Migration.swift */,
 				306A54EB23613E3A00D59A7F /* SceneDelegate.swift */,
+				E8912C292D869D6900C645B9 /* Constants.swift */,
 				306A54FF23614C0000D59A7F /* MainContainerViewController.swift */,
 				E83D87932AB3CD1E00C4113C /* FeedbackFormView.swift */,
 				E83B6D9C2D72FD6F00AA9422 /* HomeView.swift */,
@@ -1217,6 +1220,7 @@
 				E83B6DA12D781AF100AA9422 /* BMTopBlobView.swift in Sources */,
 				1336A320241D924300949F32 /* DiningItem.swift in Sources */,
 				299ACFB4244A5F90000F3E86 /* HasOccupancy.swift in Sources */,
+				E8912C2A2D869D6900C645B9 /* Constants.swift in Sources */,
 				294693A425F44AA900619481 /* MonthSelectorView.swift in Sources */,
 				2969747625D8A77C005ED231 /* UserDefaultKeys.swift in Sources */,
 				559A7B6D2373DEFA004EA501 /* MaterialTableViewCell.swift in Sources */,

--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -172,9 +172,10 @@
 		E83C6CED2B71DF190085E277 /* SafariWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83C6CEC2B71DF190085E277 /* SafariWebView.swift */; };
 		E83D87942AB3CD1E00C4113C /* FeedbackFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83D87932AB3CD1E00C4113C /* FeedbackFormView.swift */; };
 		E86F59232B9BA85700907251 /* StudyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86F59222B9BA85700907251 /* StudyViewController.swift */; };
+		E8912BE52D7FE40500C645B9 /* SafetyMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8912BE42D7FE40500C645B9 /* SafetyMapView.swift */; };
 		E8B2738D2BD5C83F0009831A /* SafetyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B2738C2BD5C83F0009831A /* SafetyView.swift */; };
 		E8B2738F2BD5E46B0009831A /* BMDrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B2738E2BD5E46B0009831A /* BMDrawerView.swift */; };
-		E8B273912BD5E5770009831A /* SafetyViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B273902BD5E5770009831A /* SafetyViewManager.swift */; };
+		E8B273912BD5E5770009831A /* SafetyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B273902BD5E5770009831A /* SafetyViewModel.swift */; };
 		E8B5975F2CA62D6F006DFBD5 /* SegmentedControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B5975E2CA62D6F006DFBD5 /* SegmentedControlView.swift */; };
 		E8BC7B652B96CB7F002BF46D /* ResourcesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BC7B642B96CB7F002BF46D /* ResourcesViewModel.swift */; };
 		E8EBE7622CEC2FD700A220BB /* SafetyLogDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EBE7612CEC2FD700A220BB /* SafetyLogDetailView.swift */; };
@@ -360,9 +361,10 @@
 		E83C6CEC2B71DF190085E277 /* SafariWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariWebView.swift; sourceTree = "<group>"; };
 		E83D87932AB3CD1E00C4113C /* FeedbackFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackFormView.swift; sourceTree = "<group>"; };
 		E86F59222B9BA85700907251 /* StudyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyViewController.swift; sourceTree = "<group>"; };
+		E8912BE42D7FE40500C645B9 /* SafetyMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyMapView.swift; sourceTree = "<group>"; };
 		E8B2738C2BD5C83F0009831A /* SafetyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyView.swift; sourceTree = "<group>"; };
 		E8B2738E2BD5E46B0009831A /* BMDrawerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BMDrawerView.swift; sourceTree = "<group>"; };
-		E8B273902BD5E5770009831A /* SafetyViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyViewManager.swift; sourceTree = "<group>"; };
+		E8B273902BD5E5770009831A /* SafetyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyViewModel.swift; sourceTree = "<group>"; };
 		E8B5975E2CA62D6F006DFBD5 /* SegmentedControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlView.swift; sourceTree = "<group>"; };
 		E8BC7B642B96CB7F002BF46D /* ResourcesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesViewModel.swift; sourceTree = "<group>"; };
 		E8EBE7612CEC2FD700A220BB /* SafetyLogDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyLogDetailView.swift; sourceTree = "<group>"; };
@@ -912,8 +914,9 @@
 			children = (
 				E8B2738C2BD5C83F0009831A /* SafetyView.swift */,
 				E8B2738E2BD5E46B0009831A /* BMDrawerView.swift */,
-				E8B273902BD5E5770009831A /* SafetyViewManager.swift */,
+				E8B273902BD5E5770009831A /* SafetyViewModel.swift */,
 				E8EBE7612CEC2FD700A220BB /* SafetyLogDetailView.swift */,
+				E8912BE42D7FE40500C645B9 /* SafetyMapView.swift */,
 			);
 			path = Safety;
 			sourceTree = "<group>";
@@ -1114,13 +1117,14 @@
 				296DDEC1253BB117008E8940 /* CampusEventDetailViewController.swift in Sources */,
 				55DCF79423723452001B01B8 /* SearchBarView.swift in Sources */,
 				1346B9172420AA4500383399 /* DayOfWeek.swift in Sources */,
+				E8912BE52D7FE40500C645B9 /* SafetyMapView.swift in Sources */,
 				29345E2D24A7FFB600859A88 /* CanFavorite.swift in Sources */,
 				1396013623865E2E005E4788 /* TagView.swift in Sources */,
 				5532B67B2390CBF600293BE0 /* MaterialLoadingIndicator.swift in Sources */,
 				13E25DFD238C949E00B670B5 /* FitnessViewController.swift in Sources */,
 				55DCF79B237243D4001B01B8 /* MaterialTextField.swift in Sources */,
 				554CB9A023F3A83F00BB1715 /* EventTableViewCell.swift in Sources */,
-				E8B273912BD5E5770009831A /* SafetyViewManager.swift in Sources */,
+				E8B273912BD5E5770009831A /* SafetyViewModel.swift in Sources */,
 				E86F59232B9BA85700907251 /* StudyViewController.swift in Sources */,
 				01B250282516AD4F00CBA459 /* IconPairView.swift in Sources */,
 				FDD7946C260FE09D00ABE60E /* Colors+AlertView.swift in Sources */,

--- a/berkeley-mobile/Assets/Colors/Colors.swift
+++ b/berkeley-mobile/Assets/Colors/Colors.swift
@@ -7,6 +7,7 @@
 //
  
 import Foundation
+import SwiftUI
 import UIKit
 
 struct BMColor {
@@ -87,6 +88,8 @@ struct BMColor {
     
 }
 
+
+// MARK: - UIColor Extension
 
 extension UIColor {
     

--- a/berkeley-mobile/Constants.swift
+++ b/berkeley-mobile/Constants.swift
@@ -1,0 +1,26 @@
+//
+//  Constants.swift
+//  berkeley-mobile
+//
+//  Created by Justin Wong on 3/15/25.
+//  Copyright © 2025 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+import MapKit
+
+struct Constants {
+    static var mapBoundsRegion: MKCoordinateRegion {
+        let fullMapCenter = CLLocationCoordinate2D(latitude: 37.76251429388581, longitude: -122.27164812506234)
+        let fullMapSpan = MKCoordinateSpan(latitudeDelta: 0.8458437031956976, longitudeDelta: 0.6425468841745499)
+        return MKCoordinateRegion(center: fullMapCenter, span: fullMapSpan)
+    }
+    
+    static var berkeleyRegion: MKCoordinateRegion {
+        let regionRadius: CLLocationDistance = 1000
+        return MKCoordinateRegion(center: berkeleyLocation.coordinate, latitudinalMeters: regionRadius * 2.0, longitudinalMeters: regionRadius * 2.0)
+    }
+    
+    static let berkeleyLocation = CLLocation(latitude: CLLocationDegrees(exactly: 37.871684)!, longitude: CLLocationDegrees(-122.259934))
+    static let mapMaxZoomDistance: CLLocationDistance = 300000
+}

--- a/berkeley-mobile/Map/MapMarkersDropdownView.swift
+++ b/berkeley-mobile/Map/MapMarkersDropdownView.swift
@@ -37,7 +37,7 @@ struct MapMarkersDropdownButton: View {
         }) {
             Image(uiImage: viewModel.selectedMapMarkerUIImage)
         }
-        .buttonStyle(HomeMapControlButtonStyle())
+        .buttonStyle(BMControlButtonStyle())
         .fullScreenCover(isPresented: $isPresentingMapMarkersDropdownView) {
             MapMarkersDropdownView(selectedMapMakerTypeCompletionHandler: selectedMapMakerTypeCompletionHandler)
                 .background(BMBackgroundBlurView().ignoresSafeArea(.all))

--- a/berkeley-mobile/Map/MapUserLocationButton.swift
+++ b/berkeley-mobile/Map/MapUserLocationButton.swift
@@ -30,7 +30,7 @@ struct MapUserLocationButton: View {
             Image(systemName: viewModel.isHomingInOnUserLocation ? "location.fill" : "location")
                 .font(.system(size: 24))
         }
-        .buttonStyle(HomeMapControlButtonStyle())
+        .buttonStyle(BMControlButtonStyle())
     }
 }
 

--- a/berkeley-mobile/Map/MapViewController.swift
+++ b/berkeley-mobile/Map/MapViewController.swift
@@ -82,14 +82,7 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
         mapView = MKMapView()
         mapView.delegate = self
         
-        // Setting the map boundaries:
-        let fullMapCenter = CLLocationCoordinate2D(latitude: 37.76251429388581, longitude: -122.27164812506234)
-        let fullMapSpan = MKCoordinateSpan(latitudeDelta: 0.8458437031956976, longitudeDelta: 0.6425468841745499)
-        let fullMapRegion = MKCoordinateRegion(center: fullMapCenter, span: fullMapSpan)
-        mapView.cameraBoundary = MKMapView.CameraBoundary(coordinateRegion: fullMapRegion)
-        let cameraDistance: CLLocationDistance = 300000
-        let maximumZoom = MKMapView.CameraZoomRange(maxCenterCoordinateDistance: cameraDistance)
-        mapView.cameraZoomRange = maximumZoom
+        setMapBoundsAndZoom()
         
         mapView.register(MKAnnotationView.self, forAnnotationViewWithReuseIdentifier: MapViewController.kAnnotationIdentifier)
         maskView = UIView()
@@ -125,9 +118,15 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
         centerMapAtBerkeley()
     }
     
+    private func setMapBoundsAndZoom() {
+        mapView.cameraBoundary = MKMapView.CameraBoundary(coordinateRegion: Constants.mapBoundsRegion)
+        let maximumZoom = MKMapView.CameraZoomRange(maxCenterCoordinateDistance: Constants.mapMaxZoomDistance)
+        mapView.cameraZoomRange = maximumZoom
+    }
+    
     private func centerMapAtBerkeley() {
         mapView.isZoomEnabled = true
-        centerMapOnLocation(CLLocation(latitude: CLLocationDegrees(exactly: 37.871684)!, longitude: CLLocationDegrees(-122.259934)), mapView: mapView, animated: false)
+        centerMapOnLocation(Constants.berkeleyLocation, mapView: mapView, animated: false)
         updateCompassPosition()
     }
     

--- a/berkeley-mobile/Map/MapViewController.swift
+++ b/berkeley-mobile/Map/MapViewController.swift
@@ -232,12 +232,12 @@ class MapViewController: UIViewController, SearchDrawerViewDelegate {
         NSLayoutConstraint.activate([
             mapUserLocationButton.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
             mapUserLocationButton.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: kViewMargin),
-            mapUserLocationButton.widthAnchor.constraint(equalToConstant: HomeMapControlButtonStyle.widthAndHeight),
-            mapUserLocationButton.heightAnchor.constraint(equalToConstant: HomeMapControlButtonStyle.widthAndHeight),
+            mapUserLocationButton.widthAnchor.constraint(equalToConstant: BMControlButtonStyle.widthAndHeight),
+            mapUserLocationButton.heightAnchor.constraint(equalToConstant: BMControlButtonStyle.widthAndHeight),
             
             mapMarkersDropdownButton.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-            mapMarkersDropdownButton.widthAnchor.constraint(equalToConstant: HomeMapControlButtonStyle.widthAndHeight),
-            mapMarkersDropdownButton.heightAnchor.constraint(equalToConstant: HomeMapControlButtonStyle.widthAndHeight),
+            mapMarkersDropdownButton.widthAnchor.constraint(equalToConstant: BMControlButtonStyle.widthAndHeight),
+            mapMarkersDropdownButton.heightAnchor.constraint(equalToConstant: BMControlButtonStyle.widthAndHeight),
             mapMarkersDropdownButton.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: kViewMargin)
         ])
     }

--- a/berkeley-mobile/Safety/BMDrawerView.swift
+++ b/berkeley-mobile/Safety/BMDrawerView.swift
@@ -129,7 +129,7 @@ struct BMDrawerView<Content: View>: View {
     private func shrinkDrawerState(to newState: BMDrawerViewState) {
         switch newState {
         case .small:
-            endOffset = startingOffset * 0.88
+            endOffset = startingOffset * 0.7
         case .medium:
             endOffset = -startingOffset / 6.8
         case .large:

--- a/berkeley-mobile/Safety/SafetyLogDetailView.swift
+++ b/berkeley-mobile/Safety/SafetyLogDetailView.swift
@@ -9,7 +9,6 @@
 import MapKit
 import SwiftUI
 
-
 struct SafetyLogDetailView: View {
     @Binding var selectedSafetyLog: BMSafetyLog?
     @Binding var drawerViewState: BMDrawerViewState
@@ -34,12 +33,11 @@ struct SafetyLogDetailView: View {
                     .shadow(color: .gray.opacity(0.5), radius: 7)
                     .padding()
                     
-                    Spacer()
                     SafetyLogView(safetyLog: selectedSafetyLog, isPresentingFullScreen: true)
-                    Spacer()
-
                 }
             }
+            
+            Spacer()
         }
     }
     

--- a/berkeley-mobile/Safety/SafetyLogDetailView.swift
+++ b/berkeley-mobile/Safety/SafetyLogDetailView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct SafetyLogDetailView: View {
     @Binding var selectedSafetyLog: BMSafetyLog?
+    @Binding var drawerViewState: BMDrawerViewState
     
     var body: some View {
         VStack {
@@ -44,7 +45,10 @@ struct SafetyLogDetailView: View {
     
     private var closeButton: some View {
         Button(action: {
-            selectedSafetyLog = nil
+            withAnimation {
+                drawerViewState = .small
+                selectedSafetyLog = nil
+            }
         }) {
             // TODO: Make into own custom view if future calls
             Image(systemName: "xmark.circle.fill")
@@ -68,7 +72,7 @@ struct SafetyLogView: View {
             mainBody
         } else {
             RoundedRectangle(cornerRadius: 10)
-                .stroke(viewModel.crimeColors[safetyLog.getSafetyLogState.rawValue] ?? .gray.opacity(0.6), lineWidth: 1)
+                .stroke(viewModel.crimeInfos[safetyLog.getSafetyLogState]?.color ?? .gray.opacity(0.6), lineWidth: 1)
                 .frame(minWidth: 300, maxWidth: 500, minHeight: 200)
                 .overlay(
                     mainBody
@@ -135,7 +139,7 @@ struct SafetyLogView: View {
 }
 
 #Preview("SafetyLogDetailView") {
-    SafetyLogDetailView(selectedSafetyLog: .constant(SafetyViewModel.getSampleSafetyLog()))
+    SafetyLogDetailView(selectedSafetyLog: .constant(SafetyViewModel.getSampleSafetyLog()), drawerViewState: .constant(.small))
         .padding()
         .environmentObject(SafetyViewModel())
 }

--- a/berkeley-mobile/Safety/SafetyLogDetailView.swift
+++ b/berkeley-mobile/Safety/SafetyLogDetailView.swift
@@ -11,8 +11,7 @@ import SwiftUI
 
 
 struct SafetyLogDetailView: View {
-    @Binding var isPresentingSafetyLogDetailView: Bool
-    var selectedSafetyLog: BMSafetyLog
+    @Binding var selectedSafetyLog: BMSafetyLog?
     
     var body: some View {
         VStack {
@@ -20,29 +19,32 @@ struct SafetyLogDetailView: View {
                 closeButton
                 Spacer()
             }
-            Spacer()
+            .padding(.bottom, 10)
             
-            Map(coordinateRegion: .constant(MKCoordinateRegion(center: selectedSafetyLog.coordinate, span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))), annotationItems: [selectedSafetyLog]) { safetyLog in
-                MapPin(coordinate: safetyLog.coordinate)
+            ScrollView(.vertical) {
+                if let selectedSafetyLog = selectedSafetyLog {
+                    Map(coordinateRegion: .constant(MKCoordinateRegion(center: selectedSafetyLog.coordinate, span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))), annotationItems: [selectedSafetyLog]) { safetyLog in
+                        MapPin(coordinate: safetyLog.coordinate)
+                    }
+                    .allowsHitTesting(false)
+                    .frame(height: 250)
+                    .frame(minWidth: 300, maxWidth: 500)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .shadow(color: .gray.opacity(0.5), radius: 7)
+                    .padding()
+                    
+                    Spacer()
+                    SafetyLogView(safetyLog: selectedSafetyLog, isPresentingFullScreen: true)
+                    Spacer()
+
+                }
             }
-            .allowsHitTesting(false)
-            .frame(height: 250)
-            .frame(minWidth: 300, maxWidth: 500)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .shadow(color: .gray.opacity(0.5), radius: 7)
-            
-            
-            Spacer()
-            SafetyLogView(safetyLog: selectedSafetyLog, isPresentingFullScreen: true)
-            Spacer()
         }
     }
     
     private var closeButton: some View {
         Button(action: {
-            withAnimation {
-                isPresentingSafetyLogDetailView.toggle()
-            }
+            selectedSafetyLog = nil
         }) {
             // TODO: Make into own custom view if future calls
             Image(systemName: "xmark.circle.fill")
@@ -56,6 +58,8 @@ struct SafetyLogDetailView: View {
 // MARK: - SafetyLogView
 
 struct SafetyLogView: View {
+    @EnvironmentObject private var viewModel: SafetyViewModel
+    
     var safetyLog: BMSafetyLog
     var isPresentingFullScreen: Bool
     
@@ -64,7 +68,7 @@ struct SafetyLogView: View {
             mainBody
         } else {
             RoundedRectangle(cornerRadius: 10)
-                .stroke(.gray.opacity(0.6), lineWidth: 1)
+                .stroke(viewModel.crimeColors[safetyLog.getSafetyLogState.rawValue] ?? .gray.opacity(0.6), lineWidth: 1)
                 .frame(minWidth: 300, maxWidth: 500, minHeight: 200)
                 .overlay(
                     mainBody
@@ -130,7 +134,14 @@ struct SafetyLogView: View {
     }
 }
 
-#Preview {
-    SafetyLogDetailView(isPresentingSafetyLogDetailView: .constant(true), selectedSafetyLog: SafetyViewManager.getSampleSafetyLog())
+#Preview("SafetyLogDetailView") {
+    SafetyLogDetailView(selectedSafetyLog: .constant(SafetyViewModel.getSampleSafetyLog()))
         .padding()
+        .environmentObject(SafetyViewModel())
+}
+
+#Preview("SafetyLogView") {
+    SafetyLogView(safetyLog: SafetyViewModel.getSampleSafetyLog(), isPresentingFullScreen: false)
+        .padding()
+        .environmentObject(SafetyViewModel())
 }

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -14,54 +14,90 @@ struct SafetyMapView: View {
     
     @State private var isShowingLegend = false
     @Binding var selectedSafetyLog: BMSafetyLog?
-    
-    private let region = MKCoordinateRegion(
-        center: CLLocation(latitude: CLLocationDegrees(exactly: 37.871684)!, longitude: CLLocationDegrees(-122.259934)).coordinate,
-        span: .init(latitudeDelta: 0.02, longitudeDelta: 0.02)
-    )
+    @Binding var drawerViewState: BMDrawerViewState
     
     var body: some View {
         if #available(iOS 17.0, *) {
-            let initialPosition = MapCameraPosition.region(region)
-            ZStack {
-                Map(initialPosition: initialPosition, selection: $selectedSafetyLog) {
-                    ForEach(safetyViewModel.filteredSafetyLogs) { safetyLog in
-                        let dateText = "\(safetyLog.date.formatted(date: .numeric, time: .shortened))"
-                        let monogramText = "\(safetyLog.crime.first!.uppercased())"
-                        Marker(dateText, monogram: Text(monogramText), coordinate: safetyLog.coordinate)
-                            .tint(safetyViewModel.crimeColors[safetyLog.getSafetyLogState.rawValue] ?? .red)
-                            .tag(safetyLog)
-                    }
-                }
-                .mapControls {
-                    MapCompass()
-                }
-                mapHUD
-            }
+            SafetyNewMapView(selectedSafetyLog: $selectedSafetyLog, isShowingLegend: $isShowingLegend, drawerViewState: $drawerViewState)
         } else {
             oldMapView
         }
     }
     
     private var oldMapView: some View {
-        Map(coordinateRegion: .constant(region), showsUserLocation: true, annotationItems: safetyViewModel.filteredSafetyLogs) { safetyLog in
+        Map(coordinateRegion: .constant(Constants.mapBoundsRegion), showsUserLocation: true, annotationItems: safetyViewModel.filteredSafetyLogs) { safetyLog in
             MapPin(coordinate: safetyLog.coordinate)
         }
         .edgesIgnoringSafeArea(.all)
     }
+}
+
+
+// MARK: - SafetyNewMapView
+
+@available(iOS 17.0, *)
+struct SafetyNewMapView: View {
+    @EnvironmentObject var safetyViewModel: SafetyViewModel
+    
+    @State private var mapCameraPosition = MapCameraPosition.automatic
+    @State private var isShowingAllMarkers = true
+    @State private var isZoomIn = true
+    @Binding var selectedSafetyLog: BMSafetyLog?
+    @Binding var isShowingLegend: Bool
+    @Binding var drawerViewState: BMDrawerViewState
+    
+    private let bounds = MapCameraBounds(centerCoordinateBounds: Constants.mapBoundsRegion, maximumDistance: Constants.mapMaxZoomDistance)
+    
+    var body: some View {
+        ZStack {
+            Map(position: $mapCameraPosition, bounds: bounds, selection: $selectedSafetyLog) {
+                ForEach(safetyViewModel.filteredSafetyLogs) { safetyLog in
+                    let dateText = "\(safetyLog.date.formatted(date: .numeric, time: .shortened))"
+                    let monogramText = "\(safetyLog.getSafetyLogState.rawValue.first!.uppercased())"
+                    Marker(dateText, monogram: Text(monogramText), coordinate: safetyLog.coordinate)
+                        .tint(safetyViewModel.crimeInfos[safetyLog.getSafetyLogState]?.color ?? .red)
+                        .tag(safetyLog)
+                }
+            }
+            .mapControlVisibility(.hidden)
+            mapHUD
+        }
+        .onChange(of: selectedSafetyLog) { newLog in
+            guard let newLog else {
+                return
+            }
+            zoomToSafetyLog(newLog)
+        }
+        .onChange(of: safetyViewModel.filteredSafetyLogs) {
+            withAnimation {
+                mapCameraPosition = .automatic
+            }
+        }
+    }
     
     @ViewBuilder
     private var mapHUD: some View {
-        if !safetyViewModel.crimeColors.isEmpty {
+        if !safetyViewModel.crimeInfos.isEmpty {
             VStack {
                 HStack(alignment: .top, spacing: 10) {
-                    if #available(iOS 17.0, *) {
-                        mapLegendButton
-                        .contentTransition(
-                            .symbolEffect(.replace)
-                        )
-                    } else {
-                        mapLegendButton
+                    VStack {
+                        if #available(iOS 17.0, *) {
+                            mapLegendButton
+                            .contentTransition(
+                                .symbolEffect(.replace)
+                            )
+                        } else {
+                            mapLegendButton
+                        }
+                        
+                        if #available(iOS 17.0, *) {
+                            mapZoomInButton
+                            .contentTransition(
+                                .symbolEffect(.replace)
+                            )
+                        } else {
+                            mapZoomInButton
+                        }
                     }
                     
                     if isShowingLegend {
@@ -90,17 +126,36 @@ struct SafetyMapView: View {
         .transition(.scale)
     }
     
+    private var mapZoomInButton: some View {
+        Button(action: {
+            withAnimation(.spring) {
+                isZoomIn.toggle()
+                mapCameraPosition = .region(Constants.berkeleyRegion)
+                drawerViewState = .small
+            }
+        }) {
+            Image(systemName: "scope")
+        }
+        .symbolEffect(.bounce, value: isZoomIn)
+        .buttonStyle(BMControlButtonStyle())
+    }
+    
     private var mapLegend: some View {
         VStack(alignment: .leading) {
-            let crimeNames = safetyViewModel.crimeColors.keys.sorted(by: { $0 < $1 })
-            ForEach(crimeNames, id: \.self) { crimeName in
-                HStack(spacing: 10) {
-                    Circle()
-                        .fill(safetyViewModel.crimeColors[crimeName] ?? .red)
-                        .frame(width: 10, height: 10)
-                    Text(crimeName.capitalized)
-                        .font(Font(BMFont.regular(18)))
-                    Spacer()
+            let crimeTypes = safetyViewModel.crimeInfos.keys.sorted(by: { $0.rawValue < $1.rawValue })
+            
+            ForEach(crimeTypes, id: \.self) { crimeType in
+                if let crimeInfo = safetyViewModel.crimeInfos[crimeType] {
+                    HStack(spacing: 10) {
+                        Circle()
+                            .fill(crimeInfo.color)
+                            .frame(width: 10, height: 10)
+                        Text(crimeType.rawValue.capitalized)
+                        Spacer()
+                        Text("\(crimeInfo.count)")
+                            .foregroundStyle(.gray)
+                    }
+                    .font(Font(BMFont.regular(18)))
                 }
             }
         }
@@ -110,9 +165,19 @@ struct SafetyMapView: View {
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .transition(.scale)
     }
+    
+    private func zoomToSafetyLog(_ log: BMSafetyLog) {
+        let region = MKCoordinateRegion(
+            center: log.coordinate,
+            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+        )
+        mapCameraPosition = .region(region)
+    }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    SafetyMapView(selectedSafetyLog: .constant(nil))
+    @Previewable @State var drawerViewState = BMDrawerViewState.medium
+    SafetyMapView(selectedSafetyLog: .constant(nil), drawerViewState: $drawerViewState)
         .environmentObject(SafetyViewModel())
 }

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -1,0 +1,118 @@
+//
+//  SafetyMapView.swift
+//  berkeley-mobile
+//
+//  Created by Justin Wong on 3/10/25.
+//  Copyright © 2025 ASUC OCTO. All rights reserved.
+//
+
+import MapKit
+import SwiftUI
+
+struct SafetyMapView: View {
+    @EnvironmentObject var safetyViewModel: SafetyViewModel
+    
+    @State private var isShowingLegend = false
+    @Binding var selectedSafetyLog: BMSafetyLog?
+    
+    private let region = MKCoordinateRegion(
+        center: CLLocation(latitude: CLLocationDegrees(exactly: 37.871684)!, longitude: CLLocationDegrees(-122.259934)).coordinate,
+        span: .init(latitudeDelta: 0.02, longitudeDelta: 0.02)
+    )
+    
+    var body: some View {
+        if #available(iOS 17.0, *) {
+            let initialPosition = MapCameraPosition.region(region)
+            ZStack {
+                Map(initialPosition: initialPosition, selection: $selectedSafetyLog) {
+                    ForEach(safetyViewModel.filteredSafetyLogs) { safetyLog in
+                        let dateText = "\(safetyLog.date.formatted(date: .numeric, time: .shortened))"
+                        let monogramText = "\(safetyLog.crime.first!.uppercased())"
+                        Marker(dateText, monogram: Text(monogramText), coordinate: safetyLog.coordinate)
+                            .tint(safetyViewModel.crimeColors[safetyLog.getSafetyLogState.rawValue] ?? .red)
+                            .tag(safetyLog)
+                    }
+                }
+                .mapControls {
+                    MapCompass()
+                }
+                mapHUD
+            }
+        } else {
+            oldMapView
+        }
+    }
+    
+    private var oldMapView: some View {
+        Map(coordinateRegion: .constant(region), showsUserLocation: true, annotationItems: safetyViewModel.filteredSafetyLogs) { safetyLog in
+            MapPin(coordinate: safetyLog.coordinate)
+        }
+        .edgesIgnoringSafeArea(.all)
+    }
+    
+    @ViewBuilder
+    private var mapHUD: some View {
+        if !safetyViewModel.crimeColors.isEmpty {
+            VStack {
+                HStack(alignment: .top, spacing: 10) {
+                    if #available(iOS 17.0, *) {
+                        mapLegendButton
+                        .contentTransition(
+                            .symbolEffect(.replace)
+                        )
+                    } else {
+                        mapLegendButton
+                    }
+                    
+                    if isShowingLegend {
+                        mapLegend
+                            .shadow(color: .gray, radius: 10)
+                    }
+                    Spacer()
+                }
+                Spacer()
+            }
+            .padding()
+        }
+    }
+    
+    private var mapLegendButton: some View {
+        Button(action: {
+            withAnimation(.spring) {
+                isShowingLegend.toggle()
+            }
+        }) {
+            Image(systemName: isShowingLegend ? "xmark" : "list.bullet")
+                .font(.system(size: 20))
+                .fontWeight(.semibold)
+        }
+        .buttonStyle(BMControlButtonStyle())
+        .transition(.scale)
+    }
+    
+    private var mapLegend: some View {
+        VStack(alignment: .leading) {
+            let crimeNames = safetyViewModel.crimeColors.keys.sorted(by: { $0 < $1 })
+            ForEach(crimeNames, id: \.self) { crimeName in
+                HStack(spacing: 10) {
+                    Circle()
+                        .fill(safetyViewModel.crimeColors[crimeName] ?? .red)
+                        .frame(width: 10, height: 10)
+                    Text(crimeName.capitalized)
+                        .font(Font(BMFont.regular(18)))
+                    Spacer()
+                }
+            }
+        }
+        .frame(width: 250)
+        .padding()
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .transition(.scale)
+    }
+}
+
+#Preview {
+    SafetyMapView(selectedSafetyLog: .constant(nil))
+        .environmentObject(SafetyViewModel())
+}

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -90,14 +90,7 @@ struct SafetyNewMapView: View {
                             mapLegendButton
                         }
                         
-                        if #available(iOS 17.0, *) {
-                            mapZoomInButton
-                            .contentTransition(
-                                .symbolEffect(.replace)
-                            )
-                        } else {
-                            mapZoomInButton
-                        }
+                        mapZoomInButton
                     }
                     
                     if isShowingLegend {

--- a/berkeley-mobile/Safety/SafetyView.swift
+++ b/berkeley-mobile/Safety/SafetyView.swift
@@ -10,34 +10,32 @@ import SwiftUI
 import MapKit
 
 struct SafetyView: View {
-    @StateObject private var safetyViewManager = SafetyViewManager()
+    @StateObject private var safetyViewModel = SafetyViewModel()
     @Namespace private var safetyLogDetailAnimation
     @State private var selectedSafetyLog: BMSafetyLog?
-    @State private var isPresentingSafetyLogDetailView = false
     @State private var drawerViewState = BMDrawerViewState.medium
-    @State var region = MKCoordinateRegion(
-        center: CLLocation(latitude: CLLocationDegrees(exactly: 37.871684)!, longitude: CLLocationDegrees(-122.259934)).coordinate,
-        span: .init(latitudeDelta: 0.02, longitudeDelta: 0.02)
-    )
+    
+    private var isPresentingSafetyLogDetailView: Bool {
+        selectedSafetyLog != nil
+    }
     
     var body: some View {
         ZStack {
             Group {
-                Map(coordinateRegion: $region, showsUserLocation: true, annotationItems: safetyViewManager.safetyLogs) { safetyLog in
-                    MapPin(coordinate: safetyLog.coordinate)
-                }
-                .edgesIgnoringSafeArea(.all)
+                SafetyMapView(selectedSafetyLog: $selectedSafetyLog)
+                    .environmentObject(safetyViewModel)
                 drawerView
             }
             .allowsHitTesting(isPresentingSafetyLogDetailView ? false : true)
             .blur(radius: isPresentingSafetyLogDetailView ? 40 : 0)
             
             if isPresentingSafetyLogDetailView {
-                SafetyLogDetailView(isPresentingSafetyLogDetailView: $isPresentingSafetyLogDetailView, selectedSafetyLog: selectedSafetyLog!)
+                SafetyLogDetailView(selectedSafetyLog: $selectedSafetyLog)
                     .padding()
                     .matchedGeometryEffect(id: selectedSafetyLog!.id, in: safetyLogDetailAnimation)
             }
         }
+        .animation(.easeInOut, value: isPresentingSafetyLogDetailView)
     }
     
     private var drawerView: some View {
@@ -45,23 +43,21 @@ struct SafetyView: View {
             VStack(alignment: .leading) {
                 alertsDrawerHeaderView
                 
-                if safetyViewManager.isFetchingLogs {
+                if safetyViewModel.isFetchingLogs {
                     loadingSafetyLogsView
                 } else {
-                    if !safetyViewManager.filteredSafetyLogs.isEmpty {
-                        List(safetyViewManager.filteredSafetyLogs, id: \.id) { safetyLog in
+                    if !safetyViewModel.filteredSafetyLogs.isEmpty {
+                        List(safetyViewModel.filteredSafetyLogs, id: \.id) { safetyLog in
                             SafetyLogView(safetyLog: safetyLog, isPresentingFullScreen: false)
                                 .contentShape(RoundedRectangle(cornerRadius: 10))
                                 .listRowBackground(Color.clear)
                                 .listRowSeparator(.hidden)
                                 .listRowInsets(EdgeInsets())
                                 .onTapGesture {
-                                    withAnimation {
-                                        selectedSafetyLog = safetyLog
-                                        isPresentingSafetyLogDetailView.toggle()
-                                    }
+                                    selectedSafetyLog = safetyLog
                                 }
                                 .matchedGeometryEffect(id: safetyLog.id, in: safetyLogDetailAnimation)
+                                .environmentObject(safetyViewModel)
                         }
                         .listStyle(PlainListStyle())
                         .scrollContentBackground(.hidden)
@@ -81,8 +77,14 @@ struct SafetyView: View {
                     .font(Font(BMFont.regular(30)))
                     .bold()
                     .font(.title)
+                if !safetyViewModel.filteredSafetyLogs.isEmpty {
+                    Spacer()
+                    Text("^[\(safetyViewModel.filteredSafetyLogs.count) Result](inflect: true)")
+                        .font(Font(BMFont.regular(16)))
+                        .foregroundStyle(.gray)
+                }
                 Spacer()
-                SafetyLogFilterButton(safetyLogFilterStates: $safetyViewManager.selectedSafetyLogFilterStates)
+                SafetyLogFilterButton(safetyLogFilterStates: $safetyViewModel.selectedSafetyLogFilterStates)
             }
             filterStatesScrollView
         }
@@ -90,18 +92,18 @@ struct SafetyView: View {
     
     @ViewBuilder
     private var filterStatesScrollView: some View {
-        if !safetyViewManager.selectedSafetyLogFilterStates.isEmpty {
+        if !safetyViewModel.selectedSafetyLogFilterStates.isEmpty {
             ScrollView(.horizontal) {
                 HStack {
-                    ForEach(safetyViewManager.selectedSafetyLogFilterStates, id: \.id) { filterState in
+                    ForEach(safetyViewModel.selectedSafetyLogFilterStates, id: \.id) { filterState in
                         HStack {
                             Text(filterState.rawValue.capitalized)
                                 .font(Font(BMFont.regular(16)))
                                 .foregroundStyle(.white)
                             Button(action: {
                                 withAnimation {
-                                    if let removeIndex = safetyViewManager.selectedSafetyLogFilterStates.firstIndex(of: filterState) {
-                                        safetyViewManager.selectedSafetyLogFilterStates.remove(at: removeIndex)
+                                    if let removeIndex = safetyViewModel.selectedSafetyLogFilterStates.firstIndex(of: filterState) {
+                                        safetyViewModel.selectedSafetyLogFilterStates.remove(at: removeIndex)
                                     }
                                 }
                             }) {

--- a/berkeley-mobile/Safety/SafetyView.swift
+++ b/berkeley-mobile/Safety/SafetyView.swift
@@ -22,7 +22,7 @@ struct SafetyView: View {
     var body: some View {
         ZStack {
             Group {
-                SafetyMapView(selectedSafetyLog: $selectedSafetyLog)
+                SafetyMapView(selectedSafetyLog: $selectedSafetyLog, drawerViewState: $drawerViewState)
                     .environmentObject(safetyViewModel)
                 drawerView
             }
@@ -30,7 +30,7 @@ struct SafetyView: View {
             .blur(radius: isPresentingSafetyLogDetailView ? 40 : 0)
             
             if isPresentingSafetyLogDetailView {
-                SafetyLogDetailView(selectedSafetyLog: $selectedSafetyLog)
+                SafetyLogDetailView(selectedSafetyLog: $selectedSafetyLog, drawerViewState: $drawerViewState)
                     .padding()
                     .matchedGeometryEffect(id: selectedSafetyLog!.id, in: safetyLogDetailAnimation)
             }
@@ -84,7 +84,7 @@ struct SafetyView: View {
                         .foregroundStyle(.gray)
                 }
                 Spacer()
-                SafetyLogFilterButton(safetyLogFilterStates: $safetyViewModel.selectedSafetyLogFilterStates)
+                SafetyLogFilterButton(safetyLogFilterStates: $safetyViewModel.selectedSafetyLogFilterStates, drawerViewState: $drawerViewState)
             }
             filterStatesScrollView
         }
@@ -104,6 +104,7 @@ struct SafetyView: View {
                                 withAnimation {
                                     if let removeIndex = safetyViewModel.selectedSafetyLogFilterStates.firstIndex(of: filterState) {
                                         safetyViewModel.selectedSafetyLogFilterStates.remove(at: removeIndex)
+                                        drawerViewState = .small
                                     }
                                 }
                             }) {
@@ -159,6 +160,7 @@ struct SafetyView: View {
 
 struct SafetyLogFilterButton: View {
     @Binding var safetyLogFilterStates: [BMSafetyLogFilterState]
+    @Binding var drawerViewState: BMDrawerViewState
     
     var body: some View {
         Menu {
@@ -196,7 +198,8 @@ struct SafetyLogFilterButton: View {
     private func addToSafetyLogFilterStates(for newFilterState: BMSafetyLogFilterState) {
         if !safetyLogFilterStates.contains(newFilterState) {
             withAnimation {
-                self.safetyLogFilterStates.append(newFilterState)
+                safetyLogFilterStates.append(newFilterState)
+                drawerViewState = .small
             }
         }
     }

--- a/berkeley-mobile/Safety/SafetyViewModel.swift
+++ b/berkeley-mobile/Safety/SafetyViewModel.swift
@@ -69,6 +69,11 @@ final class SafetyViewModel: NSObject, ObservableObject {
         static let safetyLogsCollectionName = "Safety Logs"
     }
     
+    struct BMCrimeInfo {
+        var color: Color
+        var count: Int
+    }
+    
     @Published var region = MKCoordinateRegion(
         center: CLLocation(latitude: CLLocationDegrees(exactly: 37.871684)!, longitude: CLLocationDegrees(-122.259934)).coordinate,
         span: .init(latitudeDelta: 0.02, longitudeDelta: 0.02)
@@ -76,7 +81,7 @@ final class SafetyViewModel: NSObject, ObservableObject {
     @Published var safetyLogs = [BMSafetyLog]()
     @Published var filteredSafetyLogs = [BMSafetyLog]()
     @Published var isFetchingLogs = false
-    @Published var crimeColors = [String: Color]()
+    @Published var crimeInfos = [BMSafetyLogFilterState: BMCrimeInfo]()
     @Published var selectedSafetyLogFilterStates: [BMSafetyLogFilterState] = [] {
         didSet {
             updateFilterState()
@@ -201,10 +206,9 @@ final class SafetyViewModel: NSObject, ObservableObject {
     private func associateCrimesWithColor() {
         let colors: [Color] = [.red, .green, .blue, .yellow, .purple, .orange, .mint]
         let displayCrimeTypes: [BMSafetyLogFilterState] = [.aggravatedAssault, .burglary, .robbery, .sexualAssault, .others]
-        for (crime, color) in zip(displayCrimeTypes.map { $0.rawValue }, colors) {
-            withAnimation {
-                crimeColors[crime] = color
-            }
+        for (crime, color) in zip(displayCrimeTypes, colors) {
+            let crimeTypeCount = safetyLogs.filter { $0.getSafetyLogState == crime }.count
+            crimeInfos[crime] = BMCrimeInfo(color: color, count: crimeTypeCount)
         }
     }
     

--- a/berkeley-mobile/Safety/SafetyViewModel.swift
+++ b/berkeley-mobile/Safety/SafetyViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  SafetyViewManager.swift
+//  SafetyViewModel.swift
 //  berkeley-mobile
 //
 //  Created by Justin Wong on 4/21/24.
@@ -63,7 +63,7 @@ extension BMSafetyLogFilterState: Identifiable {
 
 // MARK: - SafetyViewManager
 
-final class SafetyViewManager: NSObject, ObservableObject {
+final class SafetyViewModel: NSObject, ObservableObject {
     
     private struct Constants {
         static let safetyLogsCollectionName = "Safety Logs"
@@ -75,12 +75,13 @@ final class SafetyViewManager: NSObject, ObservableObject {
     )
     @Published var safetyLogs = [BMSafetyLog]()
     @Published var filteredSafetyLogs = [BMSafetyLog]()
+    @Published var isFetchingLogs = false
+    @Published var crimeColors = [String: Color]()
     @Published var selectedSafetyLogFilterStates: [BMSafetyLogFilterState] = [] {
         didSet {
             updateFilterState()
         }
     }
-    @Published var isFetchingLogs = false
     
     private let locationManager = CLLocationManager()
     private let db = Firestore.firestore()
@@ -126,6 +127,7 @@ final class SafetyViewManager: NSObject, ObservableObject {
                 self.safetyLogs = fetchedSafetyLogs
                 self.filteredSafetyLogs = fetchedSafetyLogs
                 self.isFetchingLogs = false
+                self.associateCrimesWithColor()
             }
         }
     }
@@ -196,12 +198,22 @@ final class SafetyViewManager: NSObject, ObservableObject {
         }
     }
     
+    private func associateCrimesWithColor() {
+        let colors: [Color] = [.red, .green, .blue, .yellow, .purple, .orange, .mint]
+        let displayCrimeTypes: [BMSafetyLogFilterState] = [.aggravatedAssault, .burglary, .robbery, .sexualAssault, .others]
+        for (crime, color) in zip(displayCrimeTypes.map { $0.rawValue }, colors) {
+            withAnimation {
+                crimeColors[crime] = color
+            }
+        }
+    }
+    
 }
 
 
 // MARK: - CLLocationManagerDelegate
 
-extension SafetyViewManager: CLLocationManagerDelegate {
+extension SafetyViewModel: CLLocationManagerDelegate {
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         guard .authorizedWhenInUse == manager.authorizationStatus else {
@@ -230,7 +242,7 @@ extension SafetyViewManager: CLLocationManagerDelegate {
 
 // MARK: - Sample Data
 
-extension SafetyViewManager {
+extension SafetyViewModel {
     
     static func getSampleSafetyLog() -> BMSafetyLog {
         BMSafetyLog(crime: "Aggravated Assault", date: Date(), detail: "On 4/10/24 at approximately 1855 hours, victim was walking north bound on Gayley Road. A blue convertible Pontiac driving south bound Gayley road from Hearst Ave struck the victim with an unknown projectile. The suspect vehicle continued south bound Gayley Road then proceeded east bound Rim Way. The vehicle was occupied by 2 males and 1 female. The rear passenger subject was responsible for the incident.   Case 24-01042  Aggravated assault is an unlawful attack by one person upon another for the purpose of inflicting severe or aggravated bodily injury. This type of assault is usually accompanied by the use of a weapon or by means likely to produce death or great bodily harm.", latitude: 1.0, location: "Gayley Road, South of Hearst Ave", longitude: 1.0)

--- a/berkeley-mobile/Utils/View+Extension.swift
+++ b/berkeley-mobile/Utils/View+Extension.swift
@@ -9,12 +9,12 @@
 import SwiftUI
 
 
-struct HomeMapControlButtonStyle: ButtonStyle {
+struct BMControlButtonStyle: ButtonStyle {
     static let widthAndHeight: CGFloat = 45
     
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(width: HomeMapControlButtonStyle.widthAndHeight, height: HomeMapControlButtonStyle.widthAndHeight)
+            .frame(width: BMControlButtonStyle.widthAndHeight, height: BMControlButtonStyle.widthAndHeight)
             .background(
                 Circle()
                     .fill(.thinMaterial)


### PR DESCRIPTION
- Conditionally switch to using new iOS 17+ SwiftUI Map API, otherwise default to current implementation
- Map Markers show first letter of the crime type name 
- Map Legend Button
- Focus on Berkeley Button
- Map is restricted to same bounds as the Home Map
- Added ScrollView to `SafetyLogDetailView` 
- Updated `BMDrawerView` `small` state to be a bit higher
- Shows number of results in Alerts header
- Crime types are color coded 
- Crime type color is show in safety log view border in the drawer

https://github.com/user-attachments/assets/6b1df3fc-b3e5-4e49-a306-d0b5245a0c8c

