### PR TITLE
BER-75: Fix MapMarkersDropdownView Regression: Row Tap Target and Font Weight

### DIFF
--- a/berkeley-mobile/Map/MapMarkersDropdownView.swift
+++ b/berkeley-mobile/Map/MapMarkersDropdownView.swift
@@ -65,7 +65,7 @@ struct MapMarkersDropdownView: View {
                     HStack(spacing: 15) {
                         Image(uiImage: type.icon())
                         Text(type.rawValue)
-                            .font(Font(BMFont.regular(20)))
+                            .font(Font(BMFont.medium(20)))
                         Spacer()
                     }
                     .contentShape(Rectangle())

--- a/berkeley-mobile/Map/MapMarkersDropdownView.swift
+++ b/berkeley-mobile/Map/MapMarkersDropdownView.swift
@@ -66,6 +66,7 @@ struct MapMarkersDropdownView: View {
                         Image(uiImage: type.icon())
                         Text(type.rawValue)
                             .font(Font(BMFont.regular(20)))
+                        Spacer()
                     }
                     .contentShape(Rectangle())
                 }

--- a/berkeley-mobile/Map/MapMarkersDropdownView.swift
+++ b/berkeley-mobile/Map/MapMarkersDropdownView.swift
@@ -65,7 +65,7 @@ struct MapMarkersDropdownView: View {
                     HStack(spacing: 15) {
                         Image(uiImage: type.icon())
                         Text(type.rawValue)
-                            .font(Font(BMFont.medium(20)))
+                            .font(Font(BMFont.regular(20)))
                         Spacer()
                     }
                     .contentShape(Rectangle())


### PR DESCRIPTION
### MapMarkersDropdownView:
  Added a `Spacer()` to the end of the `HStack` to expand the tap target area
  
### Font Weight
BMFont does not have a `semibold` variant, so I used `medium`.  
I've attached screenshots comparing `regular` vs. `medium` — feel free to share which looks better!

### regular
<img width="250" alt="BMFont regular" src="https://github.com/user-attachments/assets/bd4a8cc1-5162-488d-9c2b-56ea88a185d7" />

### medium
<img width="251" alt="BMFont medium" src="https://github.com/user-attachments/assets/4c71ff19-ab60-4b55-a3bf-83939af200ef" />


  