### PR TITLE
BER-88: Temporary Fix Crash Originating From Filter.apply(filters:on:indices:completion:)

### DIFF
--- a/berkeley-mobile/Common/FilterTableView/FilterTableView.swift
+++ b/berkeley-mobile/Common/FilterTableView/FilterTableView.swift
@@ -14,39 +14,33 @@ class FilterTableView<T>: UIView {
     let tableView = UITableView(frame: .zero, style: .plain)
     var missingView: MissingDataView!
 
-    var filter: FilterView = FilterView(frame: .zero)
     var data: [T] = []
     var filteredData: [T] = []
     var tableFunctions: [TableFunction] = []
     var sortIndex: Int?
     var defaultSort: ((T, T) -> Bool)
     
-    var isInitialSetup = true
+    init(frame: CGRect, tableFunctions: [TableFunction], defaultSort: @escaping ((T, T) -> Bool), initialSelectedIndices: [Int] = [], filterView: FilterView? = nil) {
+        self.defaultSort = defaultSort
+        super.init(frame: frame)
+        self.setupSubviews()
 
-    func setupSubviews(createFilter: Bool = true) {
+        missingView = MissingDataView(parentView: tableView, text: "No items found")
+        self.tableFunctions = tableFunctions
+
+        self.update()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setupSubviews() {
         self.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-
-        if createFilter {
-            self.addSubview(filter)
-
-            filter.translatesAutoresizingMaskIntoConstraints = false
-            filter.leftAnchor.constraint(equalTo: self.layoutMarginsGuide.leftAnchor).isActive = true
-            filter.rightAnchor.constraint(equalTo: self.layoutMarginsGuide.rightAnchor).isActive = true
-            filter.topAnchor.constraint(equalTo: self.layoutMarginsGuide.topAnchor).isActive = true
-            filter.heightAnchor.constraint(equalToConstant: FilterViewCell.kCellSize.height).isActive = true
-        }
-
         self.addSubview(tableView)
+        
         tableView.separatorStyle = UITableViewCell.SeparatorStyle.none
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        if createFilter {
-            tableView.topAnchor.constraint(equalTo: filter.bottomAnchor, constant: kViewMargin).isActive = true
-        } else {
-            tableView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
-        }
-        tableView.leftAnchor.constraint(equalTo: self.leftAnchor).isActive = true
-        tableView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
-        tableView.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
         tableView.rowHeight = 103
         tableView.layer.masksToBounds = true
         tableView.contentInset = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
@@ -54,29 +48,13 @@ class FilterTableView<T>: UIView {
         tableView.contentInsetAdjustmentBehavior = .never
         tableView.showsVerticalScrollIndicator = false
         tableView.backgroundColor = UIColor.clear
-    }
-    
-    init(frame: CGRect, tableFunctions: [TableFunction], defaultSort: @escaping ((T, T) -> Bool), initialSelectedIndices: [Int] = [], filterView: FilterView? = nil) {
-        self.defaultSort = defaultSort
-        super.init(frame: frame)
-        if let filterView = filterView {
-            filter = filterView
-            self.setupSubviews(createFilter: false)
-        } else {
-            self.setupSubviews()
-        }
-
-        missingView = MissingDataView(parentView: tableView, text: "No items found")
-        self.tableFunctions = tableFunctions
-        filter.labels = tableFunctions.map { $0.label }
-        filter.filterDelegates.append(self)
-        for index in initialSelectedIndices {
-            guard index < filter.labels.count else { continue }
-            filter.selectItem(index: index)
-        }
-        isInitialSetup = false
-
-        self.update()
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: topAnchor),
+            tableView.leftAnchor.constraint(equalTo: leftAnchor),
+            tableView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            tableView.rightAnchor.constraint(equalTo: rightAnchor)
+        ])
     }
     
     func setData(data: [T]) {
@@ -95,59 +73,18 @@ class FilterTableView<T>: UIView {
         }
     }
     
-    func setSortFunc(index: Int) {
-        if index < tableFunctions.count,
-           tableFunctions[index] as? Sort<T> != nil {
-            sortIndex = index
-            sort()
-        }
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    var workItem: DispatchWorkItem?
-    @objc func update() {
-        guard !isInitialSetup else { return }
-        workItem?.cancel()
-        let data = self.data
-        guard let paths = filter.indexPathsForSelectedItems else { return }
-        let indices = paths.map { $0.row }
-        var filters: [Filter<T>] = []
-        sortIndex = nil
-        for index in indices {
-            guard index < tableFunctions.count else { continue }
-            if let filter = tableFunctions[index] as? Filter<T> {
-                filters.append(filter)
-            } else if tableFunctions[index] as? Sort<T> != nil {
-                setSortFunc(index: index)
+    @objc
+    func update() {
+        filteredData = data
+        filteredData.sort(by: defaultSort)
+        
+        DispatchQueue.main.async {
+            if (self.filteredData.isEmpty) {
+                self.missingView.isHidden = false
+            } else {
+                self.missingView.isHidden = true
             }
+            self.tableView.reloadData()
         }
-        workItem = Filter.apply(filters: filters, on: data, completion: {
-          filtered in
-            self.filteredData = filtered
-            self.sort()
-            
-            DispatchQueue.main.async {
-                if (self.filteredData.count == 0) {
-                    self.missingView.isHidden = false
-                } else {
-                    self.missingView.isHidden = true
-                }
-                self.tableView.reloadData()
-            }
-        })
-    }
-}
-
-
-extension FilterTableView: FilterViewDelegate {
-    func filterView(_ filterView: FilterView, didSelect index: Int) {
-        update()
-    }
-    
-    func filterView(_ filterView: FilterView, didDeselect index: Int) {
-        update()
     }
 }

--- a/berkeley-mobile/Common/FilterTableView/FilterTableView.swift
+++ b/berkeley-mobile/Common/FilterTableView/FilterTableView.swift
@@ -12,15 +12,15 @@ fileprivate let kViewMargin: CGFloat = 16
 
 class FilterTableView<T>: UIView {
     let tableView = UITableView(frame: .zero, style: .plain)
-    var missingView: MissingDataView!
+    private var missingView: MissingDataView!
 
-    var data: [T] = []
     var filteredData: [T] = []
-    var tableFunctions: [TableFunction] = []
-    var sortIndex: Int?
     var defaultSort: ((T, T) -> Bool)
+
+    private var tableFunctions: [TableFunction] = []
+    private var sortIndex: Int?
     
-    init(frame: CGRect, tableFunctions: [TableFunction], defaultSort: @escaping ((T, T) -> Bool), initialSelectedIndices: [Int] = [], filterView: FilterView? = nil) {
+    init(frame: CGRect, tableFunctions: [TableFunction], defaultSort: @escaping ((T, T) -> Bool)) {
         self.defaultSort = defaultSort
         super.init(frame: frame)
         self.setupSubviews()
@@ -36,7 +36,6 @@ class FilterTableView<T>: UIView {
     }
     
     func setupSubviews() {
-        self.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         self.addSubview(tableView)
         
         tableView.separatorStyle = UITableViewCell.SeparatorStyle.none
@@ -58,7 +57,6 @@ class FilterTableView<T>: UIView {
     }
     
     func setData(data: [T]) {
-        self.data = data
         self.filteredData = data
         sort()
     }
@@ -75,8 +73,7 @@ class FilterTableView<T>: UIView {
     
     @objc
     func update() {
-        filteredData = data
-        filteredData.sort(by: defaultSort)
+        sort()
         
         DispatchQueue.main.async {
             if (self.filteredData.isEmpty) {

--- a/berkeley-mobile/Common/FilterView/Filter.swift
+++ b/berkeley-mobile/Common/FilterView/Filter.swift
@@ -14,27 +14,6 @@ struct Filter<T>: TableFunction {
     var filter: ((T) -> Bool)?
     
     /**
-        Applies filters in `filters` to `data`.
-
-        - Parameter filters:    The filters to apply.
-        - Parameter data:       An array of data to filter.
-        - Parameter indices:    The indices of active filters in `filters`. Setting this value to `nil` activates all filters.
-        - Parameter completion: A block to execute with the filtered results.
-
-        - Returns: The `DispatchWorkItem ` encapsulating the work. Use this object to cancel the work if needed.
-    */
-    static func apply(filters: [Filter<T>], on data: [T], indices: [Int]? = nil, completion: @escaping ([T]) -> Void) -> DispatchWorkItem {
-        let workItem = DispatchWorkItem {
-            let activeFilters = indices?.map { filters[$0] } ?? filters
-            completion(data.filter { datum in
-                activeFilters.allSatisfy { $0.filter?(datum) ?? true }
-            })
-        }
-        DispatchQueue.global(qos: .userInteractive).async(execute: workItem)
-        return workItem
-    }
-    
-    /**
         Filters out datum in `data` that do not satisfy at least one filter in `filters`.
 
         - Parameter filters:    The list of filters.

--- a/berkeley-mobile/Dining/DiningMenuViewController.swift
+++ b/berkeley-mobile/Dining/DiningMenuViewController.swift
@@ -54,7 +54,7 @@ class DiningMenuViewController: UIViewController {
         //        filters.append(filterForRestriction(name: "Soybeans", restriction: KnownRestriction.soybean, matches: true))
         //        filters.append(filterForRestriction(name: "Wheat", restriction: KnownRestriction.wheat, matches: true))
         //        filters.append(filterForRestriction(name: "No Sesame", restriction: KnownRestriction.sesame, matches: false))
-        menuView = FilterTableView(frame: .zero, tableFunctions: filters, defaultSort: SortingFunctions.sortAlph(item1:item2:), filterView: filter)
+        menuView = FilterTableView(frame: .zero, tableFunctions: filters, defaultSort: SortingFunctions.sortAlph(item1:item2:))
         self.menuView.tableView.register(DiningMenuCell.self, forCellReuseIdentifier: DiningMenuCell.kCellIdentifier)
         self.menuView.tableView.dataSource = self
         self.menuView.tableView.delegate = self

--- a/berkeley-mobile/Dining/DiningViewController.swift
+++ b/berkeley-mobile/Dining/DiningViewController.swift
@@ -33,7 +33,7 @@ struct DiningView: UIViewControllerRepresentable {
 
 class DiningViewController: UIViewController, SearchDrawerViewDelegate {
     
-    private var filterTableView: FilterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
+    private var filterTableView: FilterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortClose(loc1:loc2:))
     private var diningLocations: [DiningLocation] = []
     
     private var headerLabel: UILabel!
@@ -172,7 +172,7 @@ extension DiningViewController {
             Sort<DiningLocation>(label: "Nearby", sort: DiningHall.locationComparator()),
             Filter<DiningLocation>(label: "Open", filter: {diningHall in diningHall.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:), initialSelectedIndices: [0])
+        filterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortClose(loc1:loc2:), initialSelectedIndices: [0])
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = self
         self.filterTableView.tableView.delegate = self

--- a/berkeley-mobile/Dining/DiningViewController.swift
+++ b/berkeley-mobile/Dining/DiningViewController.swift
@@ -172,7 +172,7 @@ extension DiningViewController {
             Sort<DiningLocation>(label: "Nearby", sort: DiningHall.locationComparator()),
             Filter<DiningLocation>(label: "Open", filter: {diningHall in diningHall.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortClose(loc1:loc2:), initialSelectedIndices: [0])
+        filterTableView = FilterTableView<DiningLocation>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortClose(loc1:loc2:))
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = self
         self.filterTableView.tableView.delegate = self

--- a/berkeley-mobile/Fitness/FitnessViewController.swift
+++ b/berkeley-mobile/Fitness/FitnessViewController.swift
@@ -240,7 +240,7 @@ extension FitnessViewController {
             Sort<Gym>(label: "Nearby", sort: Gym.locationComparator()),
             Filter<Gym>(label: "Open", filter: {gym in gym.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortClose(loc1:loc2:), initialSelectedIndices: [0])
+        filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortClose(loc1:loc2:))
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = gymsController
         self.filterTableView.tableView.delegate = gymsController

--- a/berkeley-mobile/Fitness/FitnessViewController.swift
+++ b/berkeley-mobile/Fitness/FitnessViewController.swift
@@ -65,7 +65,7 @@ class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
     private var bClassesExpanded = false
     
     // To display a list of gyms in the "Fitness Centers" card
-    var filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
+    var filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortClose(loc1:loc2:))
     var gyms: [Gym] = []
     
     private var gymsController = GymsController()
@@ -240,7 +240,7 @@ extension FitnessViewController {
             Sort<Gym>(label: "Nearby", sort: Gym.locationComparator()),
             Filter<Gym>(label: "Open", filter: {gym in gym.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:), initialSelectedIndices: [0])
+        filterTableView = FilterTableView<Gym>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortClose(loc1:loc2:), initialSelectedIndices: [0])
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = gymsController
         self.filterTableView.tableView.delegate = gymsController

--- a/berkeley-mobile/Libraries/StudyViewController.swift
+++ b/berkeley-mobile/Libraries/StudyViewController.swift
@@ -166,7 +166,7 @@ class StudyViewController: UIViewController, UITableViewDataSource, UITableViewD
             Sort<Library>(label: "Nearby", sort: SortingFunctions.sortClose),
             Filter<Library>(label: "Open", filter: {lib in lib.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortClose(loc1:loc2:), initialSelectedIndices: [0])
+        filterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortClose(loc1:loc2:))
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = self
         self.filterTableView.tableView.delegate = self

--- a/berkeley-mobile/Libraries/StudyViewController.swift
+++ b/berkeley-mobile/Libraries/StudyViewController.swift
@@ -108,7 +108,7 @@ class StudyViewController: UIViewController, UITableViewDataSource, UITableViewD
     }
     
     // MARK: Libraries
-    var filterTableView: FilterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortAlph(item1:item2:))
+    var filterTableView: FilterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: [], defaultSort: SortingFunctions.sortClose(loc1:loc2:))
     var safeArea: UILayoutGuide!
     var libraries: [Library] = []
     
@@ -166,7 +166,7 @@ class StudyViewController: UIViewController, UITableViewDataSource, UITableViewD
             Sort<Library>(label: "Nearby", sort: SortingFunctions.sortClose),
             Filter<Library>(label: "Open", filter: {lib in lib.isOpen ?? false}),
         ]
-        filterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortAlph(item1:item2:), initialSelectedIndices: [0])
+        filterTableView = FilterTableView<Library>(frame: .zero, tableFunctions: functions, defaultSort: SortingFunctions.sortClose(loc1:loc2:), initialSelectedIndices: [0])
         self.filterTableView.tableView.register(FilterTableViewCell.self, forCellReuseIdentifier: FilterTableViewCell.kCellIdentifier)
         self.filterTableView.tableView.dataSource = self
         self.filterTableView.tableView.delegate = self


### PR DESCRIPTION
- Main culprit in majority of the crashes
- Removed `FilterView` in `FilterTableView`. Currently the feature is useless due to stale Firestore data. Second, it relied on `Filter.apply`.
- Removed `Filter.apply` function

**Run branch on your local phone and see if you experience any crashes.**