### PR TITLE
BER-90: Fix Incorrect BMCalendarView Calendar Dates

### DIFF
--- a/berkeley-mobile/Events/Calendar/BMCalendarView.swift
+++ b/berkeley-mobile/Events/Calendar/BMCalendarView.swift
@@ -30,17 +30,15 @@ class BMCalendarViewModel: ObservableObject {
     }
     
     private func populateDates() {
-        let startOfToday = Date().getStartOfDay()
-        guard let dateTwoWeeksAgo = calendar.date(byAdding: .day, value: -14, to: startOfToday),
-              let dateOneWeekFromToday = calendar.date(byAdding: .day, value: 7, to: startOfToday),
-              let nextSaturday = calendar.date(byAdding: .day, value: DayOfWeek.saturday.rawValue - DayOfWeek.weekday(dateOneWeekFromToday).rawValue + 1, to: dateOneWeekFromToday) else {
+        guard let sundayTwoWeeksAgo = Date.getDateCertainWeeksRelativeToToday(numWeeks: -2, dayOfWeek: .sunday),
+            let saturdayTwoWeeksFromNow = Date.getDateCertainWeeksRelativeToToday(numWeeks: 2, dayOfWeek: .saturday) else {
             return
         }
         
         var dates = [Date]()
-        var currentDate = dateTwoWeeksAgo
+        var currentDate = sundayTwoWeeksAgo
 
-        while currentDate <= nextSaturday {
+        while currentDate <= saturdayTwoWeeksFromNow {
             dates.append(currentDate)
             if let nextDate = calendar.date(byAdding: .day, value: 1, to: currentDate) {
                 currentDate = nextDate

--- a/berkeley-mobile/Utils/Date+Extension.swift
+++ b/berkeley-mobile/Utils/Date+Extension.swift
@@ -83,6 +83,7 @@ extension Date {
         return calendar.date(byAdding: .day, value: daysDifference, to: dateWeeksFromToday)
     } 
     
+    
     // MARK: - Instance Methods
     
     /// Returns `date` with (hour:min) of this Date.

--- a/berkeley-mobile/Utils/Date+Extension.swift
+++ b/berkeley-mobile/Utils/Date+Extension.swift
@@ -60,6 +60,29 @@ extension Date {
         }
     }
     
+    /// Get date a certain weeks from today.
+    /// - Parameters:
+    ///   - numWeeks: If negative then we get date in the past. If positive, we get date in the future
+    ///   - dayOfWeek: The `DayOfWeek` of the desired date
+    /// - Returns: Returns an Optional date
+    static func getDateCertainWeeksRelativeToToday(numWeeks: Int, dayOfWeek: DayOfWeek) -> Date? {
+        let calendar = Calendar.current
+        let startOfToday = Date().getStartOfDay()
+        
+        guard let dateWeeksFromToday = calendar.date(byAdding: .day, value: numWeeks * 7, to: startOfToday) else {
+            return nil
+        }
+        
+        let currentWeekday = dateWeeksFromToday.weekday()
+        var daysDifference = dayOfWeek.rawValue - currentWeekday
+        
+        if daysDifference < 0 {
+            daysDifference += 7
+        }
+        
+        return calendar.date(byAdding: .day, value: daysDifference, to: dateWeeksFromToday)
+    } 
+    
     // MARK: - Instance Methods
     
     /// Returns `date` with (hour:min) of this Date.


### PR DESCRIPTION
- `BMCalendarView` is displaying the incorrect date ranges. 
- Now showing two weeks ahead and only the prior week to emphasize future events

The actual current date was Fri, 3/28
**Before:**
<img width="346" alt="Screenshot 2025-03-28 at 1 49 50 PM" src="https://github.com/user-attachments/assets/1979216f-3767-409c-a33b-e647262dab29" />

**After:**
<img width="346" alt="Screenshot 2025-03-28 at 1 49 01 PM" src="https://github.com/user-attachments/assets/858d962c-89d7-4e55-ac92-a2b829271b0e" />
