### PR TITLE
BER-91: Stale Data With Gym Occupancy Views

### DIFF
--- a/berkeley-mobile/Fitness/GymOccupancyView.swift
+++ b/berkeley-mobile/Fitness/GymOccupancyView.swift
@@ -37,9 +37,6 @@ struct GymOccupancyView: View {
                 viewModel.startAutoRefresh()
             }
         }
-        .onDisappear {
-            viewModel.stopAutoRefresh()
-        }
     }
 }
 


### PR DESCRIPTION
After some time, the gym occupancy views do not update/refresh after `FitnessViewController` is out of view 
- Removed `onDisappear` view modifier since that stopped the updating 