### PR TITLE
BER-99: Fix Resources Section Header Text and Title Alignment

### DIFF
--- a/berkeley-mobile/Resources/ResourcesSectionDropdown.swift
+++ b/berkeley-mobile/Resources/ResourcesSectionDropdown.swift
@@ -30,6 +30,8 @@ struct ResourcesSectionDropdown<Content: View>: View {
                     .font(Font(BMFont.bold(25)))
                     .foregroundColor(Color.primary)
                     .padding(.vertical, 16)
+                    .multilineTextAlignment(.leading)
+                
                 Spacer()
 
                 Image(systemName: "chevron.right")
@@ -111,6 +113,8 @@ struct ResourceItemView: View {
                     .foregroundColor(.primary)
                     .padding(.leading, 16)
                     .padding(.vertical, 8)
+                    .multilineTextAlignment(.leading)
+                
                 Spacer()
 
                 Image(systemName: "chevron.right")

--- a/berkeley-mobile/Resources/ResourcesView.swift
+++ b/berkeley-mobile/Resources/ResourcesView.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-
 // MARK: ResourcesView
 
 struct ResourcesView: View {
@@ -25,43 +24,44 @@ struct ResourcesView: View {
         NavigationStack {
             ZStack {
                 BMTopBlobView(imageName: "BlobRight", xOffset: 30, width: 150, height: 150)
-        
-                VStack {
-                    if !resourcesVM.shoutouts.isEmpty  {
-                        resourceShoutoutsTabView
-                    }
                     
                     if resourcesVM.resourceCategories.isEmpty {
                        noResourcesAvailableView
                     } else {
-                        SegmentedControlView(
-                            tabNames: resourcesVM.resourceCategoryNames,
-                            selectedTabIndex: $tabSelectedValue
-                        )
-                        .padding()
-                        
-                        TabView(selection: $tabSelectedValue) {
-                            ForEach(Array(resourcesVM.resourceCategories.enumerated()), id: \.offset) { idx, category in
-                                ResourcePageView(resourceSections: category.sections).tag(idx)
+                        VStack {
+                            if !resourcesVM.shoutouts.isEmpty  {
+                                resourceShoutoutsTabView
                             }
+                            
+                            SegmentedControlView(
+                                tabNames: resourcesVM.resourceCategoryNames,
+                                selectedTabIndex: $tabSelectedValue
+                            )
+                            .padding()
+                            
+                            TabView(selection: $tabSelectedValue) {
+                                ForEach(Array(resourcesVM.resourceCategories.enumerated()), id: \.offset) { idx, category in
+                                    ResourcePageView(resourceSections: category.sections).tag(idx)
+                                }
+                            }
+                            .tabViewStyle(.page(indexDisplayMode: .never))
+                            
+                            Spacer()
                         }
-                        .tabViewStyle(.page(indexDisplayMode: .never))
+                        .navigationTitle("Resources")
                     }
-                    Spacer()
-                }
-                .navigationTitle("Resources")
             }
             .background(Color(BMColor.cardBackground))
         }
     }
     
     private var noResourcesAvailableView: some View {
-        VStack {
-            Spacer()
-            Text("No Resources Available")
-                .font(Font(BMFont.bold(21)))
-            Spacer()
-        }
+        BMContentUnavailableView(
+                iconName: "exclamationmark.triangle",
+                title: "No Resources Available",
+                subtitle: "Try again later."
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
     
     private var resourceShoutoutsTabView: some View {

--- a/berkeley-mobile/Resources/ResourcesView.swift
+++ b/berkeley-mobile/Resources/ResourcesView.swift
@@ -25,31 +25,27 @@ struct ResourcesView: View {
             ZStack {
                 BMTopBlobView(imageName: "BlobRight", xOffset: 30, width: 150, height: 150)
                     
+                VStack {
                     if resourcesVM.resourceCategories.isEmpty {
-                       noResourcesAvailableView
+                        noResourcesAvailableView
                     } else {
-                        VStack {
-                            if !resourcesVM.shoutouts.isEmpty  {
-                                resourceShoutoutsTabView
+                        SegmentedControlView(
+                            tabNames: resourcesVM.resourceCategoryNames,
+                            selectedTabIndex: $tabSelectedValue
+                        )
+                        .padding()
+                        
+                        TabView(selection: $tabSelectedValue) {
+                            ForEach(Array(resourcesVM.resourceCategories.enumerated()), id: \.offset) { idx, category in
+                                ResourcePageView(resourceSections: category.sections).tag(idx)
                             }
-                            
-                            SegmentedControlView(
-                                tabNames: resourcesVM.resourceCategoryNames,
-                                selectedTabIndex: $tabSelectedValue
-                            )
-                            .padding()
-                            
-                            TabView(selection: $tabSelectedValue) {
-                                ForEach(Array(resourcesVM.resourceCategories.enumerated()), id: \.offset) { idx, category in
-                                    ResourcePageView(resourceSections: category.sections).tag(idx)
-                                }
-                            }
-                            .tabViewStyle(.page(indexDisplayMode: .never))
-                            
-                            Spacer()
                         }
-                        .navigationTitle("Resources")
+                        .tabViewStyle(.page(indexDisplayMode: .never))
+                        
+                        Spacer()
                     }
+                }
+                .navigationTitle("Resources")
             }
             .background(Color(BMColor.cardBackground))
         }
@@ -62,6 +58,7 @@ struct ResourcesView: View {
                 subtitle: "Try again later."
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .offset(y: -45)
     }
     
     private var resourceShoutoutsTabView: some View {


### PR DESCRIPTION
- fixed alignment for the titles of both `ResourcesSectionDropdown` and `ResourceItemView`
- refactored the `noResourcesAvailableView` to use `BMContentUnavailableView`
- deleted shoutouts block

before / after:
<p align="center">
<img src="https://github.com/user-attachments/assets/b141272d-f214-4d55-bab6-7c88a88da231" alt="Screenshot" width="300"/>

<img src="https://github.com/user-attachments/assets/92345555-0ae2-4873-bce0-4743d775f47b" alt="Screenshot" width="300"/>
</p>

---

before / after:
<p align="center">
<img src="https://github.com/user-attachments/assets/d2092b1b-e530-49aa-8231-c1049281e2f5" alt="Screenshot" width="300"/>

<img src="https://github.com/user-attachments/assets/c06e19d5-4372-4416-af6a-2d30c8187626" alt="Screenshot" width="300"/>
</p>

---

before / after:
<p align="center">
<img src="https://github.com/user-attachments/assets/c600e7e9-9fc9-4dcc-a824-95454bc7693a" alt="Screenshot" width="300"/>

<img src="https://github.com/user-attachments/assets/d8d4440c-d576-4c2b-8c34-9d1d3887fd75" alt="Screenshot" width="300"/>
</p>
