### PR TITLE
BER-92: Gym Occupancy Home Screen Widgets

### DIFF
--- a/BerkeleyMobileWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/BerkeleyMobileWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BerkeleyMobileWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/BerkeleyMobileWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BerkeleyMobileWidget/Assets.xcassets/Contents.json
+++ b/BerkeleyMobileWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BerkeleyMobileWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/BerkeleyMobileWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BerkeleyMobileWidget/BerkeleyMobileWidgetBundle.swift
+++ b/BerkeleyMobileWidget/BerkeleyMobileWidgetBundle.swift
@@ -1,0 +1,17 @@
+//
+//  BerkeleyMobileWidgetBundle.swift
+//  BerkeleyMobileWidget
+//
+//  Created by Justin Wong on 4/13/25.
+//  Copyright © 2025 ASUC OCTO. All rights reserved.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct BerkeleyMobileWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        GymOccupancyWidget()
+    }
+}

--- a/BerkeleyMobileWidget/GymOccupancyWidget.swift
+++ b/BerkeleyMobileWidget/GymOccupancyWidget.swift
@@ -1,0 +1,209 @@
+//
+//  GymOccupancyWidget.swift
+//  GymOccupancyWidget
+//
+//  Created by Justin Wong on 4/13/25.
+//  Copyright © 2025 ASUC OCTO. All rights reserved.
+//
+
+import SwiftUI
+import WidgetKit
+
+typealias GymOccupancyChange = (prior: Double?, current: Double)
+
+struct GymOccupancyEntry: TimelineEntry {
+    static let defaultRSFOccupancyPercentages: GymOccupancyChange = (100, 91)
+    static let defaultStadiumOccupancyPercentages: GymOccupancyChange = (43, 68)
+    
+    let date: Date
+    let RSFOccupancyPercentages: GymOccupancyChange
+    let stadiumOccupancyPercentages: GymOccupancyChange
+}
+
+class GymOccupancyEntryCache {
+    var entry: GymOccupancyEntry?
+}
+
+
+// MARK: - GymOccupancyProvider
+
+struct GymOccupancyProvider: TimelineProvider {
+    private let rsfGymOccupancyViewModel = GymOccupancyViewModel(location: .rsf)
+    private let stadiumGymOccupancyViewModel = GymOccupancyViewModel(location: .stadium)
+    private let entryCache = GymOccupancyEntryCache()
+    
+    private var priorRSFOccupancy: Double?  {
+        entryCache.entry?.RSFOccupancyPercentages.current
+    }
+    private var priorStadiumOccupancy: Double? {
+        entryCache.entry?.stadiumOccupancyPercentages.current
+    }
+    
+    func placeholder(in context: Context) -> GymOccupancyEntry {
+        GymOccupancyEntry(
+            date: Date(),
+            RSFOccupancyPercentages: GymOccupancyEntry.defaultRSFOccupancyPercentages,
+            stadiumOccupancyPercentages: GymOccupancyEntry.defaultStadiumOccupancyPercentages
+        )
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (GymOccupancyEntry) -> ()) {
+        let areOccupancyPercentagesUnavailable = rsfGymOccupancyViewModel.occupancyPercentage == nil && stadiumGymOccupancyViewModel.occupancyPercentage == nil
+        
+        if context.isPreview && areOccupancyPercentagesUnavailable {
+            let entry = GymOccupancyEntry(
+                date: Date(),
+                RSFOccupancyPercentages: GymOccupancyEntry.defaultRSFOccupancyPercentages,
+                stadiumOccupancyPercentages: GymOccupancyEntry.defaultStadiumOccupancyPercentages
+            )
+            completion(entry)
+        } else {
+            fetchGymOccupancies { currRSFOccupancy, currStadiumOccupancy in
+                let entry = GymOccupancyEntry(date: Date(),
+                                          RSFOccupancyPercentages: (priorRSFOccupancy, currRSFOccupancy),
+                                          stadiumOccupancyPercentages: (priorStadiumOccupancy, currStadiumOccupancy))
+                completion(entry)
+            }
+        }
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        fetchGymOccupancies { currRSFOccupancy, currStadiumOccupancy in
+            let entry = GymOccupancyEntry(
+                date: Date(),
+                RSFOccupancyPercentages: (priorRSFOccupancy, currRSFOccupancy),
+                stadiumOccupancyPercentages: (priorStadiumOccupancy, currStadiumOccupancy)
+            )
+            
+            entryCache.entry = entry
+            
+            let timeline = Timeline(entries: [entry], policy: .atEnd)
+            completion(timeline)
+        }
+    }
+    
+    private func fetchGymOccupancies(completion: @escaping (Double, Double) -> Void) {
+        rsfGymOccupancyViewModel.refreshWithCompletionHandler { RSFOccupancy in
+            stadiumGymOccupancyViewModel.refreshWithCompletionHandler { stadiumOccupancy in
+               completion(RSFOccupancy ?? 0, stadiumOccupancy ?? 0)
+            }
+        }
+    }
+}
+
+
+// MARK: - GymOccupancyWidgetEntryView
+
+struct GymOccupancyWidgetEntryView : View {
+    var entry: GymOccupancyProvider.Entry
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Spacer()
+            GymOccupancyWidgetRowView(location: .rsf, entry: entry)
+            Spacer()
+            GymOccupancyWidgetRowView(location: .stadium, entry: entry)
+            Spacer()
+            relativeDateText
+            Spacer()
+        }
+        .padding(.leading)
+    }
+    
+    private var relativeDateText: some View {
+        Text("\(Text(entry.date, style: .relative)) ago")
+            .font(Font(BMFont.regular(10)))
+            .fontWeight(.medium)
+    }
+}
+
+
+// MARK: - GymOccupancyWidgetRowView
+
+struct GymOccupancyWidgetRowView: View {
+    var location: GymOccupancyLocation
+    var entry: GymOccupancyEntry
+    
+    private var occupancyColor: Color {
+        switch location {
+        case .rsf:
+            GymOccupancyViewModel.getOccupancyColor(percentage: entry.RSFOccupancyPercentages.current)
+        case .stadium:
+            GymOccupancyViewModel.getOccupancyColor(percentage: entry.stadiumOccupancyPercentages.current)
+        }
+    }
+    
+    private var occupancyPercentage: Double {
+        switch location {
+        case .rsf:
+            return entry.RSFOccupancyPercentages.current
+        case .stadium:
+            return entry.stadiumOccupancyPercentages.current
+        }
+    }
+    
+    private var isAnIncrease: Bool {
+        switch location {
+        case .rsf:
+            return entry.RSFOccupancyPercentages.current > entry.RSFOccupancyPercentages.prior ?? 0.0
+        case .stadium:
+            return entry.stadiumOccupancyPercentages.current > entry.stadiumOccupancyPercentages.prior ?? 0.0
+        }
+    }
+    
+    var body: some View {
+        Text(location.rawValue)
+            .font(Font(BMFont.regular(13)))
+            .bold()
+        HStack {
+            increaseDecreaseIndicator
+            occupancyPercentageText
+        }
+    }
+    
+    private var increaseDecreaseIndicator: some View {
+        Image(systemName: "triangle.fill")
+            .rotationEffect(isAnIncrease ? .degrees(0) : .degrees(180))
+            .foregroundStyle(isAnIncrease ? .red : .green)
+            .font(.system(size: 16))
+    }
+    
+    private var occupancyPercentageText: some View {
+        Text("\(Int(occupancyPercentage))")
+            .foregroundStyle(occupancyColor)
+            .contentTransition(.numericText(value: occupancyPercentage))
+            .font(.system(size: 30))
+            .fontWeight(.semibold)
+    }
+}
+
+
+// MARK: - GymOccupancyWidget
+
+struct GymOccupancyWidget: Widget {
+    let kind: String = "GymOccupancyWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: GymOccupancyProvider()) { entry in
+            if #available(iOS 17.0, *) {
+                GymOccupancyWidgetEntryView(entry: entry)
+                    .containerBackground(.fill.tertiary, for: .widget)
+            } else {
+                GymOccupancyWidgetEntryView(entry: entry)
+                    .padding()
+                    .background()
+            }
+        }
+        .contentMarginsDisabled()
+        .configurationDisplayName("Gym Occupancy")
+        .description("View the current RSF Weight Rooms and CMS Fitness Center occupancies.")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+#Preview(as: .systemSmall) {
+    GymOccupancyWidget()
+} timeline: {
+    GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (71, 93), stadiumOccupancyPercentages: (68, 40))
+    GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (93, 74), stadiumOccupancyPercentages: (40, 43))
+}

--- a/BerkeleyMobileWidget/GymOccupancyWidget.swift
+++ b/BerkeleyMobileWidget/GymOccupancyWidget.swift
@@ -142,12 +142,12 @@ struct GymOccupancyWidgetRowView: View {
         }
     }
     
-    private var isAnIncrease: Bool {
+    private var percentageDiff: Double {
         switch location {
         case .rsf:
-            return entry.RSFOccupancyPercentages.current > entry.RSFOccupancyPercentages.prior ?? 0.0
+            return entry.RSFOccupancyPercentages.current - (entry.RSFOccupancyPercentages.prior ?? 0.0)
         case .stadium:
-            return entry.stadiumOccupancyPercentages.current > entry.stadiumOccupancyPercentages.prior ?? 0.0
+            return entry.stadiumOccupancyPercentages.current - (entry.stadiumOccupancyPercentages.prior ?? 0.0)
         }
     }
     
@@ -156,15 +156,18 @@ struct GymOccupancyWidgetRowView: View {
             .font(Font(BMFont.regular(13)))
             .bold()
         HStack {
-            increaseDecreaseIndicator
+            if percentageDiff != 0 {
+                increaseDecreaseIndicator
+                    .transition(.scale)
+            }
             occupancyPercentageText
         }
     }
     
     private var increaseDecreaseIndicator: some View {
         Image(systemName: "triangle.fill")
-            .rotationEffect(isAnIncrease ? .degrees(0) : .degrees(180))
-            .foregroundStyle(isAnIncrease ? .red : .green)
+            .rotationEffect(percentageDiff > 0 ? .degrees(0) : .degrees(180))
+            .foregroundStyle(percentageDiff > 0 ? .red : .green)
             .font(.system(size: 16))
     }
     
@@ -206,4 +209,6 @@ struct GymOccupancyWidget: Widget {
 } timeline: {
     GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (71, 93), stadiumOccupancyPercentages: (68, 40))
     GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (93, 74), stadiumOccupancyPercentages: (40, 43))
+    GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (74, 74), stadiumOccupancyPercentages: (40, 40))
+    GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (74, 108), stadiumOccupancyPercentages: (40, 9))
 }

--- a/BerkeleyMobileWidget/GymOccupancyWidget.swift
+++ b/BerkeleyMobileWidget/GymOccupancyWidget.swift
@@ -28,7 +28,7 @@ class GymOccupancyEntryCache {
 // MARK: - GymOccupancyProvider
 
 struct GymOccupancyProvider: TimelineProvider {
-    private let rsfGymOccupancyViewModel = GymOccupancyViewModel(location: .rsf)
+    private let RSFGymOccupancyViewModel = GymOccupancyViewModel(location: .rsf)
     private let stadiumGymOccupancyViewModel = GymOccupancyViewModel(location: .stadium)
     private let entryCache = GymOccupancyEntryCache()
     
@@ -48,7 +48,7 @@ struct GymOccupancyProvider: TimelineProvider {
     }
 
     func getSnapshot(in context: Context, completion: @escaping (GymOccupancyEntry) -> ()) {
-        let areOccupancyPercentagesUnavailable = rsfGymOccupancyViewModel.occupancyPercentage == nil && stadiumGymOccupancyViewModel.occupancyPercentage == nil
+        let areOccupancyPercentagesUnavailable = RSFGymOccupancyViewModel.occupancyPercentage == nil && stadiumGymOccupancyViewModel.occupancyPercentage == nil
         
         if context.isPreview && areOccupancyPercentagesUnavailable {
             let entry = GymOccupancyEntry(
@@ -59,7 +59,7 @@ struct GymOccupancyProvider: TimelineProvider {
             completion(entry)
         } else {
             let entry = GymOccupancyEntry(date: Date(),
-                                          RSFOccupancyPercentages: (priorRSFOccupancy, rsfGymOccupancyViewModel.occupancyPercentage ?? 0),
+                                          RSFOccupancyPercentages: (priorRSFOccupancy, RSFGymOccupancyViewModel.occupancyPercentage ?? 0),
                                           stadiumOccupancyPercentages: ( priorStadiumOccupancy,stadiumGymOccupancyViewModel.occupancyPercentage ?? 0))
             completion(entry)
         }
@@ -81,7 +81,7 @@ struct GymOccupancyProvider: TimelineProvider {
     }
     
     private func fetchGymOccupancies(completion: @escaping (Double, Double) -> Void) {
-        rsfGymOccupancyViewModel.refreshWithCompletionHandler { RSFOccupancy in
+        RSFGymOccupancyViewModel.refreshWithCompletionHandler { RSFOccupancy in
             stadiumGymOccupancyViewModel.refreshWithCompletionHandler { stadiumOccupancy in
                completion(RSFOccupancy ?? 0, stadiumOccupancy ?? 0)
             }

--- a/BerkeleyMobileWidget/GymOccupancyWidget.swift
+++ b/BerkeleyMobileWidget/GymOccupancyWidget.swift
@@ -58,12 +58,10 @@ struct GymOccupancyProvider: TimelineProvider {
             )
             completion(entry)
         } else {
-            fetchGymOccupancies { currRSFOccupancy, currStadiumOccupancy in
-                let entry = GymOccupancyEntry(date: Date(),
-                                          RSFOccupancyPercentages: (priorRSFOccupancy, currRSFOccupancy),
-                                          stadiumOccupancyPercentages: (priorStadiumOccupancy, currStadiumOccupancy))
-                completion(entry)
-            }
+            let entry = GymOccupancyEntry(date: Date(),
+                                          RSFOccupancyPercentages: (priorRSFOccupancy, rsfGymOccupancyViewModel.occupancyPercentage ?? 0),
+                                          stadiumOccupancyPercentages: ( priorStadiumOccupancy,stadiumGymOccupancyViewModel.occupancyPercentage ?? 0))
+            completion(entry)
         }
     }
 

--- a/BerkeleyMobileWidget/GymOccupancyWidget.swift
+++ b/BerkeleyMobileWidget/GymOccupancyWidget.swift
@@ -156,19 +156,17 @@ struct GymOccupancyWidgetRowView: View {
             .font(Font(BMFont.regular(13)))
             .bold()
         HStack {
-            if percentageDiff != 0 {
-                increaseDecreaseIndicator
-                    .transition(.scale)
-            }
+            increaseDecreaseIndicator
             occupancyPercentageText
         }
     }
     
     private var increaseDecreaseIndicator: some View {
-        Image(systemName: "triangle.fill")
-            .rotationEffect(percentageDiff > 0 ? .degrees(0) : .degrees(180))
+        Image(systemName: percentageDiff == 0 ? "equal.circle.fill" : "triangle.fill")
+            .rotationEffect(percentageDiff >= 0 ? .degrees(0) : .degrees(180))
             .foregroundStyle(percentageDiff > 0 ? .red : .green)
             .font(.system(size: 16))
+            .frame(width: 20)
     }
     
     private var occupancyPercentageText: some View {
@@ -209,6 +207,6 @@ struct GymOccupancyWidget: Widget {
 } timeline: {
     GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (71, 93), stadiumOccupancyPercentages: (68, 40))
     GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (93, 74), stadiumOccupancyPercentages: (40, 43))
-    GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (74, 74), stadiumOccupancyPercentages: (40, 40))
+    GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (74, 74), stadiumOccupancyPercentages: (43, 40))
     GymOccupancyEntry(date: .now, RSFOccupancyPercentages: (74, 108), stadiumOccupancyPercentages: (40, 9))
 }

--- a/BerkeleyMobileWidget/Info.plist
+++ b/BerkeleyMobileWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -176,6 +176,22 @@
 		E83D87942AB3CD1E00C4113C /* FeedbackFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83D87932AB3CD1E00C4113C /* FeedbackFormView.swift */; };
 		E86F59232B9BA85700907251 /* StudyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86F59222B9BA85700907251 /* StudyViewController.swift */; };
 		E889F75C2DA323C100202556 /* BMActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E889F75B2DA323C100202556 /* BMActionButton.swift */; };
+		E889F7FC2DAC4DEE00202556 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E889F7FB2DAC4DEE00202556 /* WidgetKit.framework */; };
+		E889F7FE2DAC4DEE00202556 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E889F7FD2DAC4DEE00202556 /* SwiftUI.framework */; };
+		E889F8092DAC4DEF00202556 /* BerkeleyMobileWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E889F7FA2DAC4DEE00202556 /* BerkeleyMobileWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		E889F80F2DAC4FAE00202556 /* GymOccupancyScrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83B6DA42D7A85D500AA9422 /* GymOccupancyScrapper.swift */; };
+		E889F8112DAC516100202556 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = E889F8102DAC516100202556 /* SwiftSoup */; };
+		E889F8122DAC664E00202556 /* GymOccupancyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83B6DA82D7A860E00AA9422 /* GymOccupancyViewModel.swift */; };
+		E889F82E2DAC9FC100202556 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCF78823722CF1001B01B8 /* Fonts.swift */; };
+		E889F82F2DACA02C00202556 /* Apercu Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D2698A2544D86B000377B4 /* Apercu Light.otf */; };
+		E889F8302DACA02C00202556 /* Apercu Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D269912544D86C000377B4 /* Apercu Medium.otf */; };
+		E889F8312DACA02C00202556 /* Apercu Medium Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D269902544D86C000377B4 /* Apercu Medium Italic.otf */; };
+		E889F8322DACA02C00202556 /* Apercu Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D2698E2544D86C000377B4 /* Apercu Bold.otf */; };
+		E889F8332DACA02C00202556 /* Apercu Bold Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D2698D2544D86B000377B4 /* Apercu Bold Italic.otf */; };
+		E889F8342DACA02C00202556 /* Apercu Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D2698B2544D86B000377B4 /* Apercu Italic.otf */; };
+		E889F8352DACA02C00202556 /* Apercu Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D269922544D86C000377B4 /* Apercu Regular.otf */; };
+		E889F8362DACA02C00202556 /* Apercu Mono.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D2698F2544D86C000377B4 /* Apercu Mono.otf */; };
+		E889F8372DACA02C00202556 /* Apercu Light Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 01D2698C2544D86B000377B4 /* Apercu Light Italic.otf */; };
 		E8912BE52D7FE40500C645B9 /* SafetyMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8912BE42D7FE40500C645B9 /* SafetyMapView.swift */; };
 		E8912C2A2D869D6900C645B9 /* BMConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8912C292D869D6900C645B9 /* BMConstants.swift */; };
 		E8B2738D2BD5C83F0009831A /* SafetyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B2738C2BD5C83F0009831A /* SafetyView.swift */; };
@@ -194,6 +210,30 @@
 		FD44FE6125EB0EAD00F713EB /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD44FE6025EB0EAD00F713EB /* AlertView.swift */; };
 		FDD7946C260FE09D00ABE60E /* Colors+AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDD7946B260FE09D00ABE60E /* Colors+AlertView.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E889F8072DAC4DEF00202556 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 306A54DE23613E3A00D59A7F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E889F7F92DAC4DEE00202556;
+			remoteInfo = BerkeleyMobileWidgetExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		E889F80A2DAC4DEF00202556 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				E889F8092DAC4DEF00202556 /* BerkeleyMobileWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		009098AE14DA5A91CB4733A6 /* Pods_berkeley_mobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_berkeley_mobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -373,6 +413,9 @@
 		E83D87932AB3CD1E00C4113C /* FeedbackFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackFormView.swift; sourceTree = "<group>"; };
 		E86F59222B9BA85700907251 /* StudyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyViewController.swift; sourceTree = "<group>"; };
 		E889F75B2DA323C100202556 /* BMActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BMActionButton.swift; sourceTree = "<group>"; };
+		E889F7FA2DAC4DEE00202556 /* BerkeleyMobileWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BerkeleyMobileWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		E889F7FB2DAC4DEE00202556 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		E889F7FD2DAC4DEE00202556 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		E8912BE42D7FE40500C645B9 /* SafetyMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyMapView.swift; sourceTree = "<group>"; };
 		E8912C292D869D6900C645B9 /* BMConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BMConstants.swift; sourceTree = "<group>"; };
 		E8B2738C2BD5C83F0009831A /* SafetyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyView.swift; sourceTree = "<group>"; };
@@ -391,6 +434,20 @@
 		FDD7946B260FE09D00ABE60E /* Colors+AlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+AlertView.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		E889F80D2DAC4DEF00202556 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = E889F7F92DAC4DEE00202556 /* BerkeleyMobileWidgetExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		E889F7FF2DAC4DEE00202556 /* BerkeleyMobileWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E889F80D2DAC4DEF00202556 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = BerkeleyMobileWidget; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		306A54E323613E3A00D59A7F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -398,6 +455,16 @@
 			files = (
 				47E625C4AFB6802788C56FCC /* Pods_berkeley_mobile.framework in Frameworks */,
 				E8FCD6842C374A81004B66A3 /* SwiftSoup in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E889F7F72DAC4DEE00202556 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E889F7FE2DAC4DEE00202556 /* SwiftUI.framework in Frameworks */,
+				E889F7FC2DAC4DEE00202556 /* WidgetKit.framework in Frameworks */,
+				E889F8112DAC516100202556 /* SwiftSoup in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -820,6 +887,7 @@
 			isa = PBXGroup;
 			children = (
 				306A54E823613E3A00D59A7F /* berkeley-mobile */,
+				E889F7FF2DAC4DEE00202556 /* BerkeleyMobileWidget */,
 				306A54E723613E3A00D59A7F /* Products */,
 				D7D8E5ACD8A49B3560D555D9 /* Pods */,
 				133864A62404E7C4001F9048 /* Recovered References */,
@@ -831,6 +899,7 @@
 			isa = PBXGroup;
 			children = (
 				306A54E623613E3A00D59A7F /* Berkeley.app */,
+				E889F7FA2DAC4DEE00202556 /* BerkeleyMobileWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -929,6 +998,8 @@
 			isa = PBXGroup;
 			children = (
 				009098AE14DA5A91CB4733A6 /* Pods_berkeley_mobile.framework */,
+				E889F7FB2DAC4DEE00202556 /* WidgetKit.framework */,
+				E889F7FD2DAC4DEE00202556 /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -968,10 +1039,12 @@
 				306A54E323613E3A00D59A7F /* Frameworks */,
 				306A54E423613E3A00D59A7F /* Resources */,
 				5F6013C0C645F1FA4C0EFACB /* [CP] Embed Pods Frameworks */,
+				E889F80A2DAC4DEF00202556 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				E889F8082DAC4DEF00202556 /* PBXTargetDependency */,
 			);
 			name = "berkeley-mobile";
 			packageProductDependencies = (
@@ -981,18 +1054,44 @@
 			productReference = 306A54E623613E3A00D59A7F /* Berkeley.app */;
 			productType = "com.apple.product-type.application";
 		};
+		E889F7F92DAC4DEE00202556 /* BerkeleyMobileWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E889F80E2DAC4DEF00202556 /* Build configuration list for PBXNativeTarget "BerkeleyMobileWidgetExtension" */;
+			buildPhases = (
+				E889F7F62DAC4DEE00202556 /* Sources */,
+				E889F7F72DAC4DEE00202556 /* Frameworks */,
+				E889F7F82DAC4DEE00202556 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				E889F7FF2DAC4DEE00202556 /* BerkeleyMobileWidget */,
+			);
+			name = BerkeleyMobileWidgetExtension;
+			packageProductDependencies = (
+				E889F8102DAC516100202556 /* SwiftSoup */,
+			);
+			productName = BerkeleyMobileWidgetExtension;
+			productReference = E889F7FA2DAC4DEE00202556 /* BerkeleyMobileWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		306A54DE23613E3A00D59A7F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1100;
+				LastSwiftUpdateCheck = 1630;
 				LastUpgradeCheck = 1100;
 				ORGANIZATIONNAME = "ASUC OCTO";
 				TargetAttributes = {
 					306A54E523613E3A00D59A7F = {
 						CreatedOnToolsVersion = 11.0;
+					};
+					E889F7F92DAC4DEE00202556 = {
+						CreatedOnToolsVersion = 16.3;
 					};
 				};
 			};
@@ -1013,6 +1112,7 @@
 			projectRoot = "";
 			targets = (
 				306A54E523613E3A00D59A7F /* berkeley-mobile */,
+				E889F7F92DAC4DEE00202556 /* BerkeleyMobileWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -1034,6 +1134,22 @@
 				01D269972544D86C000377B4 /* Apercu Bold.otf in Resources */,
 				01D269982544D86C000377B4 /* Apercu Mono.otf in Resources */,
 				01D2699B2544D86C000377B4 /* Apercu Regular.otf in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E889F7F82DAC4DEE00202556 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E889F82F2DACA02C00202556 /* Apercu Light.otf in Resources */,
+				E889F8302DACA02C00202556 /* Apercu Medium.otf in Resources */,
+				E889F8312DACA02C00202556 /* Apercu Medium Italic.otf in Resources */,
+				E889F8322DACA02C00202556 /* Apercu Bold.otf in Resources */,
+				E889F8332DACA02C00202556 /* Apercu Bold Italic.otf in Resources */,
+				E889F8342DACA02C00202556 /* Apercu Italic.otf in Resources */,
+				E889F8352DACA02C00202556 /* Apercu Regular.otf in Resources */,
+				E889F8362DACA02C00202556 /* Apercu Mono.otf in Resources */,
+				E889F8372DACA02C00202556 /* Apercu Light Italic.otf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1265,7 +1381,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E889F7F62DAC4DEE00202556 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E889F8122DAC664E00202556 /* GymOccupancyViewModel.swift in Sources */,
+				E889F82E2DAC9FC100202556 /* Fonts.swift in Sources */,
+				E889F80F2DAC4FAE00202556 /* GymOccupancyScrapper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E889F8082DAC4DEF00202556 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E889F7F92DAC4DEE00202556 /* BerkeleyMobileWidgetExtension */;
+			targetProxy = E889F8072DAC4DEF00202556 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		306A54F423613E3D00D59A7F /* LaunchScreen.storyboard */ = {
@@ -1441,6 +1575,76 @@
 			};
 			name = Release;
 		};
+		E889F80B2DAC4DEF00202556 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4HBETBULVA;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BerkeleyMobileWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = BerkeleyMobileWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 ASUC OCTO. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.asuc.ASUC.BerkeleyMobileWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E889F80C2DAC4DEF00202556 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4HBETBULVA;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BerkeleyMobileWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = BerkeleyMobileWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 ASUC OCTO. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.asuc.ASUC.BerkeleyMobileWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1462,6 +1666,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		E889F80E2DAC4DEF00202556 /* Build configuration list for PBXNativeTarget "BerkeleyMobileWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E889F80B2DAC4DEF00202556 /* Debug */,
+				E889F80C2DAC4DEF00202556 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -1476,6 +1689,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		E889F8102DAC516100202556 /* SwiftSoup */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E8FCD6822C374A81004B66A3 /* XCRemoteSwiftPackageReference "SwiftSoup" */;
+			productName = SwiftSoup;
+		};
 		E8FCD6832C374A81004B66A3 /* SwiftSoup */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E8FCD6822C374A81004B66A3 /* XCRemoteSwiftPackageReference "SwiftSoup" */;

--- a/berkeley-mobile/Fitness/FitnessViewController.swift
+++ b/berkeley-mobile/Fitness/FitnessViewController.swift
@@ -163,7 +163,7 @@ extension FitnessViewController {
         scrollView.addSubview(RSFCard)
         self.RSFCard = RSFCard
         
-        let RSFView = UIHostingController(rootView: GymOccupancyView(viewModel: homeViewModel.rsfOccupancyViewModel)).view!
+        let RSFView = UIHostingController(rootView: GymOccupancyView().environmentObject(homeViewModel.rsfOccupancyViewModel)).view!
         RSFView.translatesAutoresizingMaskIntoConstraints = false
         RSFView.layer.cornerRadius = 12
         RSFView.backgroundColor = UIColor.clear
@@ -192,7 +192,7 @@ extension FitnessViewController {
         CMSCard.translatesAutoresizingMaskIntoConstraints = false
         scrollView.addSubview(CMSCard)
         
-        let CMSView = UIHostingController(rootView: GymOccupancyView(viewModel: homeViewModel.stadiumOccupancyViewModel)).view!
+        let CMSView = UIHostingController(rootView: GymOccupancyView().environmentObject(homeViewModel.stadiumOccupancyViewModel)).view!
         CMSView.translatesAutoresizingMaskIntoConstraints = false
         CMSView.layer.cornerRadius = 12
         CMSView.backgroundColor = UIColor.clear

--- a/berkeley-mobile/Fitness/FitnessViewController.swift
+++ b/berkeley-mobile/Fitness/FitnessViewController.swift
@@ -9,6 +9,7 @@
 import Firebase
 import UIKit
 import SwiftUI
+import WidgetKit
 
 // MARK: - FitnessView
 
@@ -110,6 +111,8 @@ class FitnessViewController: UIViewController, SearchDrawerViewDelegate {
                 }
             }
         }
+        
+        WidgetCenter.shared.reloadTimelines(ofKind: "GymOccupancyWidget")
     }
     
     @objc func willExpandClasses() {

--- a/berkeley-mobile/Fitness/GymOccupancyScrapper.swift
+++ b/berkeley-mobile/Fitness/GymOccupancyScrapper.swift
@@ -11,8 +11,8 @@ import SwiftSoup
 import WebKit
 
 protocol GymOccupancyScrapperDelegate: AnyObject {
-    func rsfScrapperDidFinishScrapping(result: String?)
-    func rsfScrapperDidError(with errorDescription: String)
+    func scrapperDidFinishScrapping(result: String?)
+    func scrapperDidError(with errorDescription: String)
 }
 
 class GymOccupancyScrapper: NSObject {
@@ -62,14 +62,14 @@ extension GymOccupancyScrapper: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         guard currNumOfRescrapes < allowedNumOfRescrapes else {
             currNumOfRescrapes = 0
-            delegate?.rsfScrapperDidError(with: "Cannot load events in reasonable time. Please try again later.")
+            delegate?.scrapperDidError(with: "Cannot load events in reasonable time. Please try again later.")
             return
         }
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             webView.evaluateJavaScript("document.body.innerHTML") { result, error in
                 guard let htmlContent = result as? String, error == nil else {
-                    self.delegate?.rsfScrapperDidError(with: error?.localizedDescription ?? "Unrecognized error message")
+                    self.delegate?.scrapperDidError(with: error?.localizedDescription ?? "Unrecognized error message")
                     return
                 }
                 
@@ -77,7 +77,7 @@ extension GymOccupancyScrapper: WKNavigationDelegate {
                     let doc = try SwiftSoup.parse(htmlContent)
                     
                     if let weightOccupancyText = try doc.select("div.styles_fullness__rayxl > span").first()?.text() {
-                        self.delegate?.rsfScrapperDidFinishScrapping(result: weightOccupancyText)
+                        self.delegate?.scrapperDidFinishScrapping(result: weightOccupancyText)
                         self.occupancyText = weightOccupancyText
     
                     } else {
@@ -87,7 +87,7 @@ extension GymOccupancyScrapper: WKNavigationDelegate {
                         }
                     }
                 } catch {
-                    self.delegate?.rsfScrapperDidError(with: error.localizedDescription)
+                    self.delegate?.scrapperDidError(with: error.localizedDescription)
                 }
             }
         }

--- a/berkeley-mobile/Fitness/GymOccupancyView.swift
+++ b/berkeley-mobile/Fitness/GymOccupancyView.swift
@@ -9,17 +9,7 @@
 import SwiftUI
 
 struct GymOccupancyView: View {
-    @ObservedObject var viewModel: GymOccupancyViewModel
-    
-    private struct Constants {
-        static let minOccupancy: CGFloat = 0
-        static let maxOccupancy: CGFloat = 100
-        static let labelSize: CGFloat = 9
-        
-        static let mediumLowerBound: CGFloat = 70
-        static let mediumHighBound: CGFloat = 90
-        static let highHighBound: CGFloat = 200
-    }
+    @EnvironmentObject var viewModel: GymOccupancyViewModel
     
     var body: some View {
         VStack {
@@ -44,43 +34,25 @@ struct GymOccupancyView: View {
 // MARK: - GymOccupancyGaugeView
 
 struct GymOccupancyGaugeView: View {
+    @EnvironmentObject var viewModel: GymOccupancyViewModel
+    
     var occupancy: Double
     var gymName: String
     
-    private struct Constants {
-        static let minOccupancy: CGFloat = 0
-        static let maxOccupancy: CGFloat = 100
-        
-        static let mediumLowerBound: CGFloat = 70
-        static let mediumHighBound: CGFloat = 90
-        static let highHighBound: CGFloat = 200
-    }
-    
     var body: some View {
-        Gauge(value: occupancy, in: Constants.minOccupancy...Constants.maxOccupancy) {
+        Gauge(value: occupancy, in: GymOccupancyViewModel.Constants.minOccupancy...GymOccupancyViewModel.Constants.maxOccupancy) {
             Text(gymName)
         } currentValueLabel: {
             Text("\(Int(occupancy))")
         } minimumValueLabel: {
-            Text("\(Int(Constants.minOccupancy))")
+            Text("\(Int(GymOccupancyViewModel.Constants.minOccupancy))")
                 .foregroundStyle(.green)
         } maximumValueLabel: {
-            Text("\(Int(Constants.maxOccupancy))")
+            Text("\(Int(GymOccupancyViewModel.Constants.maxOccupancy))")
                 .foregroundStyle(.red)
         }
         .gaugeStyle(.accessoryCircular)
-        .tint(getGaugeColor(occupancy))
-    }
-    
-    private func getGaugeColor(_ value: Double) -> Color {
-        switch value {
-        case Constants.mediumLowerBound...Constants.mediumHighBound:
-            .orange
-        case Constants.mediumHighBound...Constants.highHighBound:
-            .red
-        default:
-            .green
-        }
+        .tint(GymOccupancyViewModel.getOccupancyColor(percentage: occupancy))
     }
 }
 
@@ -108,6 +80,8 @@ struct GymRedactedOccupancyGaugeView: View {
 #Preview {
     Group {
         GymOccupancyGaugeView(occupancy: 78, gymName: "RSF Weight Rooms")
+            .environmentObject(GymOccupancyViewModel(location: .rsf))
         GymRedactedOccupancyGaugeView(gymLocationName: "CMS Fitness Center")
+            .environmentObject(GymOccupancyViewModel(location: .stadium))
     }
 }

--- a/berkeley-mobile/Fitness/GymOccupancyViewModel.swift
+++ b/berkeley-mobile/Fitness/GymOccupancyViewModel.swift
@@ -7,7 +7,6 @@
 //
 
 import SwiftUI
-import WidgetKit
 
 typealias GymOccupancyLocation = GymOccupancyViewModel.GymOccupancyLocation
 
@@ -97,7 +96,6 @@ extension GymOccupancyViewModel: GymOccupancyScrapperDelegate {
         DispatchQueue.main.async {
             self.isLoading = false
             if let result, let occupancy = result.split(separator: "%").first {
-                WidgetCenter.shared.reloadTimelines(ofKind: "GymOccupancyWidget")
                 self.occupancyPercentage = Double(String(occupancy))
                 self.completionHandler?(Double(String(occupancy)))
                 self.errorMessage = nil


### PR DESCRIPTION
- Added new `.systemSmall` widget that displays both the gym occupancies for both RSF Weight Rooms and CMS Fitness Center
- Going the the Fitness Tab in the app will automatically refresh widgets 
- Refreshes ~every 15 mins (fastest that we can do as we are restricted by WidgetKit and iOS)

![screenshot_2025-04-14_at_5 37 14___pm_480](https://github.com/user-attachments/assets/6b9014cb-f38c-42a5-84f2-0b82ba3f3410)
![screenshot_2025-04-14_at_5 37 37___pm_480](https://github.com/user-attachments/assets/483a593f-bbc2-4377-a3b1-7df616e926f7)
