### PR TITLE
BER-106: Rewrite EventManager.shared.addEventToCalendar using Async & iOS 17 API

### DIFF
--- a/berkeley-mobile/Data/EventManager.swift
+++ b/berkeley-mobile/Data/EventManager.swift
@@ -9,7 +9,7 @@
 import EventKit
 import Foundation
 
-class EventManager: NSObject {
+class EventManager {
     static let shared = EventManager()
     
     private let eventStore = EKEventStore()

--- a/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
+++ b/berkeley-mobile/Data/ItemProtocols/CalendarEvent.swift
@@ -42,15 +42,14 @@ extension CalendarEvent {
         let alertController = AlertView(headingText: "Add to Calendar", messageText: "Would you like to add this event to your calendar?", action1Label: "Cancel", action1Color: BMColor.AlertView.secondaryButton, action1Completion: {
             vc.dismiss(animated: true, completion: nil)
         }, action2Label: "Yes", action2Color: BMColor.ActionButton.background, action2Completion: {
-            EventManager.shared.addEventToCalendar(calendarEvent: self) { success in
-                DispatchQueue.main.async {
-                    if success {
-                        vc.dismiss(animated: true, completion: nil)
-                        vc.presentSuccessAlert(title: "Successfully added to calendar")
-                    } else {
-                        vc.dismiss(animated: true, completion: nil)
-                        vc.presentFailureAlert(title: "Failed to add to calendar", message: "Make sure Berkeley Mobile has access to your calendar and try again.")
-                    }
+            Task { @MainActor in
+                do {
+                    try await EventManager.shared.addEventToCalendar(calendarEvent: self)
+                    vc.dismiss(animated: true, completion: nil)
+                    vc.presentSuccessAlert(title: "Successfully added to calendar")
+                } catch {
+                    vc.dismiss(animated: true, completion: nil)
+                    vc.presentFailureAlert(title: "Failed to add to calendar", message: "Make sure Berkeley Mobile has access to your calendar and try again.")
                 }
             }
         }, withOnlyOneAction: false)

--- a/berkeley-mobile/Events/Academic/AcademicCalendarViewModel.swift
+++ b/berkeley-mobile/Events/Academic/AcademicCalendarViewModel.swift
@@ -46,14 +46,15 @@ class AcademicCalendarViewModel: ObservableObject {
     }
     
     private func addAcademicEventToCalendar(_ event: EventCalendarEntry) {
-        EventManager.shared.addEventToCalendar(calendarEvent: event) { success in
-            DispatchQueue.main.async {
+        Task { @MainActor in
+            do {
+                try await EventManager.shared.addEventToCalendar(calendarEvent: event)
                 withoutAnimation {
-                    if success {
-                        self.alert = BMAlert(title: "", message: "Successfully added to calendar!", type: .notice)
-                    } else {
-                        self.alert = BMAlert(title: "Failed to add to calendar", message: "Make sure Berkeley Mobile has access to your calendar and try again.", type: .notice)
-                    }
+                    self.alert = BMAlert(title: "", message: "Successfully added to calendar!", type: .notice)
+                }
+            } catch {
+                withoutAnimation {
+                    self.alert = BMAlert(title: "Failed to add to calendar", message: "Make sure Berkeley Mobile has access to your calendar and try again.", type: .notice)
                 }
             }
         }


### PR DESCRIPTION
- Use the iOS 17 API invariant: `requestWriteOnlyAccessToEvents()` on `EKEventStore`
- For versions lower than iOS 17, use the depreciated async variant instead of the current completion handler one:
`eventStore.requestAccess(to: .event)` on `EKEventStore`
- Update relevant places calling `EventManager.shared.addEventToCalendar` with Swift Concurrency