### PR TITLE
BER-108: Prevent Readding Events To Calendar

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		E891E29B2DCD4E37006CA0F5 /* BMAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E891E29A2DCD4E37006CA0F5 /* BMAlertView.swift */; };
 		E891E2AD2DD00449006CA0F5 /* CampuswideEventsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E891E2AC2DD00449006CA0F5 /* CampuswideEventsView.swift */; };
 		E891E2AF2DD05029006CA0F5 /* BMNoEventsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E891E2AE2DD05029006CA0F5 /* BMNoEventsView.swift */; };
+		E891E2D92DD526FC006CA0F5 /* BMError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E891E2D82DD526FC006CA0F5 /* BMError.swift */; };
 		E89A33152DCB21780068DDAA /* AcademicEventRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89A33142DCB21780068DDAA /* AcademicEventRowView.swift */; };
 		E8B2738D2BD5C83F0009831A /* SafetyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B2738C2BD5C83F0009831A /* SafetyView.swift */; };
 		E8B2738F2BD5E46B0009831A /* BMDrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B2738E2BD5E46B0009831A /* BMDrawerView.swift */; };
@@ -420,6 +421,7 @@
 		E891E29A2DCD4E37006CA0F5 /* BMAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BMAlertView.swift; sourceTree = "<group>"; };
 		E891E2AC2DD00449006CA0F5 /* CampuswideEventsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampuswideEventsView.swift; sourceTree = "<group>"; };
 		E891E2AE2DD05029006CA0F5 /* BMNoEventsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BMNoEventsView.swift; sourceTree = "<group>"; };
+		E891E2D82DD526FC006CA0F5 /* BMError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BMError.swift; sourceTree = "<group>"; };
 		E89A33142DCB21780068DDAA /* AcademicEventRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademicEventRowView.swift; sourceTree = "<group>"; };
 		E8B2738C2BD5C83F0009831A /* SafetyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyView.swift; sourceTree = "<group>"; };
 		E8B2738E2BD5E46B0009831A /* BMDrawerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BMDrawerView.swift; sourceTree = "<group>"; };
@@ -905,6 +907,7 @@
 				E83D87932AB3CD1E00C4113C /* FeedbackFormView.swift */,
 				E83B6D9C2D72FD6F00AA9422 /* HomeView.swift */,
 				E8C2BD312D8A475300165554 /* Constants.swift */,
+				E891E2D82DD526FC006CA0F5 /* BMError.swift */,
 				13EA64CE2399D4A100FD8E13 /* Data */,
 				13B39A8E23E6A1ED0039FBA2 /* Libraries */,
 				136DC9792398B43F009B1810 /* Fitness */,
@@ -1296,6 +1299,7 @@
 				55DCF78923722CF1001B01B8 /* Fonts.swift in Sources */,
 				296F1B272439341300924C8D /* DiningDetailViewController.swift in Sources */,
 				13492D2D240E179F00AD3D1F /* MapMarkerDetailView.swift in Sources */,
+				E891E2D92DD526FC006CA0F5 /* BMError.swift in Sources */,
 				1346B9192420AD4800383399 /* WeeklyHours.swift in Sources */,
 				29B1D307254E1C8700BAD88F /* EventManager.swift in Sources */,
 				E8C2BDA72D912B3A00165554 /* BMCalendarView.swift in Sources */,
@@ -1522,7 +1526,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "berkeley-mobile/berkeley-mobile.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 4HBETBULVA;
 				INFOPLIST_FILE = "berkeley-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
@@ -1546,7 +1550,7 @@
 				CODE_SIGN_ENTITLEMENTS = "berkeley-mobile/berkeley-mobile.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 4HBETBULVA;
 				INFOPLIST_FILE = "berkeley-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;

--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -1526,7 +1526,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "berkeley-mobile/berkeley-mobile.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 4HBETBULVA;
 				INFOPLIST_FILE = "berkeley-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
@@ -1550,7 +1550,7 @@
 				CODE_SIGN_ENTITLEMENTS = "berkeley-mobile/berkeley-mobile.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 4HBETBULVA;
 				INFOPLIST_FILE = "berkeley-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;

--- a/berkeley-mobile/BMError.swift
+++ b/berkeley-mobile/BMError.swift
@@ -1,0 +1,28 @@
+//
+//  BMError.swift
+//  berkeley-mobile
+//
+//  Created by Justin Wong on 5/14/25.
+//  Copyright © 2025 ASUC OCTO. All rights reserved.
+//
+
+import Foundation
+
+enum BMError: Error {
+    case eventAlreadyAddedInCalendar
+    case insufficientAccessToCalendar
+    case mayExistedInCalendarAlready
+}
+
+extension BMError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .insufficientAccessToCalendar:
+            return NSLocalizedString("Insufficient permissions to access your calendar. Please go to Settings to allow calendar access.", comment: "Insufficent Permissions Error")
+        case .eventAlreadyAddedInCalendar:
+            return NSLocalizedString("Event has already been added to your calendar.", comment: "Event Already Added To Calendar Error")
+        case .mayExistedInCalendarAlready:
+            return NSLocalizedString("Event may already have been added to your calendar.", comment: "Event May Already Been Added Error")
+        }
+    }
+}

--- a/berkeley-mobile/BMError.swift
+++ b/berkeley-mobile/BMError.swift
@@ -20,9 +20,9 @@ extension BMError: LocalizedError {
         case .insufficientAccessToCalendar:
             return NSLocalizedString("Insufficient permissions to access your calendar. Please go to Settings to allow calendar access.", comment: "Insufficent Permissions Error")
         case .eventAlreadyAddedInCalendar:
-            return NSLocalizedString("Event has already been added to your calendar.", comment: "Event Already Added To Calendar Error")
+            return NSLocalizedString("This event is already in your calendar.", comment: "Event Already Added To Calendar Error")
         case .mayExistedInCalendarAlready:
-            return NSLocalizedString("Event may already have been added to your calendar.", comment: "Event May Already Been Added Error")
+            return NSLocalizedString("This event may already be in your calendar. Please check for duplicates.", comment: "Event May Already Been Added Error")
         }
     }
 }

--- a/berkeley-mobile/Constants.swift
+++ b/berkeley-mobile/Constants.swift
@@ -11,22 +11,3 @@ import UIKit
 struct Constants {
     static let doeGladeImage = UIImage(imageLiteralResourceName: "DoeGlade")
 }
-
-enum BMError: Error {
-    case eventAlreadyAddedInCalendar
-    case insufficientAccessToCalendar
-    case mayExistedInCalendarAlready
-}
-
-extension BMError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case .insufficientAccessToCalendar:
-            return NSLocalizedString("Insufficient permissions to access your calendar. Please go to Settings to allow calendar access.", comment: "Insufficent Permissions Error")
-        case .eventAlreadyAddedInCalendar:
-            return NSLocalizedString("Event has already been added to your calendar.", comment: "Event Already Added To Calendar Error")
-        case .mayExistedInCalendarAlready:
-            return NSLocalizedString("Event maybe have been added to your calendar already.", comment: "Event May Already Been Added Error")
-        }
-    }
-}

--- a/berkeley-mobile/Constants.swift
+++ b/berkeley-mobile/Constants.swift
@@ -11,3 +11,22 @@ import UIKit
 struct Constants {
     static let doeGladeImage = UIImage(imageLiteralResourceName: "DoeGlade")
 }
+
+enum BMError: Error {
+    case eventAlreadyAddedInCalendar
+    case insufficientAccessToCalendar
+    case mayExistedInCalendarAlready
+}
+
+extension BMError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .insufficientAccessToCalendar:
+            return NSLocalizedString("Insufficient permissions to access your calendar. Please go to Settings to allow calendar access.", comment: "Insufficent Permissions Error")
+        case .eventAlreadyAddedInCalendar:
+            return NSLocalizedString("Event has already been added to your calendar.", comment: "Event Already Added To Calendar Error")
+        case .mayExistedInCalendarAlready:
+            return NSLocalizedString("Event maybe have been added to your calendar already.", comment: "Event May Already Been Added Error")
+        }
+    }
+}

--- a/berkeley-mobile/Data/EventManager.swift
+++ b/berkeley-mobile/Data/EventManager.swift
@@ -53,7 +53,7 @@ class EventManager {
                 }
             }
         } catch {
-            if let ekError = error as? EKError, ekError.code == .alarmGreaterThanRecurrence {
+            if let ekError = error as? EKError, ekError.errorCode == 1 {
                 throw BMError.insufficientAccessToCalendar
             } else {
                 throw error

--- a/berkeley-mobile/Data/EventManager.swift
+++ b/berkeley-mobile/Data/EventManager.swift
@@ -59,7 +59,7 @@ class EventManager {
                 }
             }
         } catch {
-            if let ekError = error as? EKError, ekError.errorCode == 1 {
+            if let ekError = error as? EKError, ekError.code == .alarmGreaterThanRecurrence {
                 throw BMError.insufficientAccessToCalendar
             } else {
                 throw error

--- a/berkeley-mobile/Events/EventDataSource/EventsViewModel.swift
+++ b/berkeley-mobile/Events/EventDataSource/EventsViewModel.swift
@@ -37,7 +37,11 @@ class EventsViewModel: ObservableObject {
                 }
             } catch {
                 withoutAnimation {
-                    self.alert = BMAlert(title: "Failed to add to calendar", message: "Make sure Berkeley Mobile has access to your calendar and try again.", type: .notice)
+                    if let bmError = error as? BMError, bmError == .mayExistedInCalendarAlready {
+                        self.alert = BMAlert(title: "Successfully added to calendar!", message: error.localizedDescription, type: .notice)
+                    } else {
+                        self.alert = BMAlert(title: "Failed to add to calendar", message: error.localizedDescription, type: .notice)
+                    }
                 }
             }
         }

--- a/berkeley-mobile/Info.plist
+++ b/berkeley-mobile/Info.plist
@@ -38,6 +38,8 @@
 	</dict>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Calendar access will be used to allow you to add events you select to your calendar.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Calendar access will be used to allow you to appropriately add events you select to your calendar.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Your location will be used to calculate distance to points of interest, display your location on the map, and for other location-based features.</string>
 	<key>UIAppFonts</key>


### PR DESCRIPTION
- Add detailed error messages for different Calendar permission settings 
- Prevents user for adding existing event (if permissions is set to full access)
- If permissions is set to "Write-Only" display alert that mentions that there's a possible for event duplication since there's no way to knowing existing events