### PR TITLE
BER-115: Move Add To Calendar Event Action Button To Toolbar

### DIFF
--- a/berkeley-mobile/Events/Campus/CampusEventDetailView.swift
+++ b/berkeley-mobile/Events/Campus/CampusEventDetailView.swift
@@ -27,6 +27,15 @@ struct CampusEventDetailView: View {
             }
         }
         .background(Color(BMColor.modalBackground))
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: {
+                    eventsViewModel.showAddEventToCalendarAlert(event)
+                }) {
+                    Image(systemName: "calendar.badge.plus")
+                }
+            }
+        }
         .onChange(of: alertType) { type in
             presentAlert(type: type)
         }
@@ -52,10 +61,6 @@ struct CampusEventDetailView: View {
                 BMActionButton(title: "Register") {
                     alertType = .register
                 }
-            }
-            
-            BMActionButton(title: "Add To Calendar") {
-                eventsViewModel.showAddEventToCalendarAlert(event)
             }
         }
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
- Remove "Add To Calendar" Action Button in `CampusEventDetailView.swift` and move it as a trailing `ToolbarItem` button
- ![Simulator Screenshot - iPhone 16 Pro - 2025-05-25 at 11 18 59](https://github.com/user-attachments/assets/9b62b01a-c23b-40ab-b205-389cc1943492)
