### PR TITLE
BER-116: Empty Event Location Name Shows Pin SF Symbol

### DIFF
--- a/berkeley-mobile/Events/Campus/CampusEventDetailView.swift
+++ b/berkeley-mobile/Events/Campus/CampusEventDetailView.swift
@@ -140,7 +140,7 @@ struct BMDetailHeaderView: View {
     
     @ViewBuilder
     private var locationView: some View {
-        if let location = event.location {
+        if let location = event.location, !location.isEmpty {
             HStack {
                 Image(systemName: "mappin.and.ellipse")
                     .font(.system(size: 16))


### PR DESCRIPTION
- Fix bug where if event location is an empty string, the pin SF symbol still shows