### PR TITLE
BER-124: Use Defer For Loading Status

### DIFF
--- a/berkeley-mobile/Resources/ResourcesViewModel.swift
+++ b/berkeley-mobile/Resources/ResourcesViewModel.swift
@@ -45,11 +45,11 @@ class ResourcesViewModel: ObservableObject {
     private func fetchResourceCategories() async {
         do {
             isLoading = true
+            defer {
+                isLoading = false
+            }
             let sortedCategories = try await BMNetworkingManager.shared.fetchResourcesCategories()
             resourceCategories = sortedCategories
-            isLoading = false
-        } catch {
-            isLoading = false
-        }
+        } catch {}
     }
 }

--- a/berkeley-mobile/Safety/SafetyViewModel.swift
+++ b/berkeley-mobile/Safety/SafetyViewModel.swift
@@ -83,15 +83,15 @@ final class SafetyViewModel: NSObject, ObservableObject {
     private func listenForSafetyLogs() async {
         do {
             isLoading = true
+            defer {
+                isLoading = false
+            }
             let fetchedSafetyLogs = try await BMNetworkingManager.shared.fetchSafetyLogs()
             safetyLogs = fetchedSafetyLogs
             filteredSafetyLogs = filteredSafetyLogs == safetyLogs ? fetchedSafetyLogs : filteredSafetyLogs
             updateFilterState()
             associateCrimesWithColor()
-            isLoading = false
-        } catch {
-            isLoading = false
-        }
+        } catch {}
     }
     
     private func updateFilterState() {


### PR DESCRIPTION
Use `defer` when setting the `isLoading` status to false in the Events, Safety, and Resources Tabs.