### PR TITLE
BER-136: SF Symbol Not Showing In RecentSearchListRowView

### DIFF
--- a/berkeley-mobile/Home/Map/SearchResultsListRowView.swift
+++ b/berkeley-mobile/Home/Map/SearchResultsListRowView.swift
@@ -62,12 +62,19 @@ struct RecentSearchListRowView: View {
     
     var body: some View {
         HStack {
-            Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 24)
-                .foregroundStyle(Color(BMColor.searchBarIconColor))
-                .frame(width: 52)
+            Group {
+                if #available(iOS 18.0, *) {
+                    Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                        .resizable()
+                } else {
+                    Image(systemName: "clock")
+                        .resizable()
+                }
+            }
+            .scaledToFit()
+            .frame(width: 24)
+            .foregroundStyle(Color(BMColor.searchBarIconColor))
+            .frame(width: 52)
             
             Text(codablePlacemark.searchName ?? "Not Available")
                 .font(Font(BMFont.regular(16)))


### PR DESCRIPTION
- Use `clock` SF Symbol for recent search history for versions under iOS 18.0

Recording showing fixed bug in iOS 17.4 with clock SF symbol showing: 
https://github.com/user-attachments/assets/5f6ac2b5-b372-4748-867e-172fd419eadf

