### PR TITLE
Regression: Adding Event To Calendar Does Not Show Already Added UI

### DIFF
--- a/berkeley-mobile/Data/BMEventManager.swift
+++ b/berkeley-mobile/Data/BMEventManager.swift
@@ -48,7 +48,10 @@ class BMEventManager {
     }
     
     private func getMatchingEvents(for calendarEvent: BMCalendarEvent) -> [EKEvent] {
-        let predicate = eventStore.predicateForEvents(withStart: calendarEvent.startDate, end: calendarEvent.endDate, calendars: nil)
+        guard let endDate = Calendar.current.date(byAdding: .year, value: 1, to: calendarEvent.startDate) else {
+            return []
+        }
+        let predicate = eventStore.predicateForEvents(withStart: calendarEvent.startDate, end: endDate, calendars: nil)
         let existingEvents = eventStore.events(matching: predicate)
         return existingEvents
     }


### PR DESCRIPTION
- After adding an academic or campus wide event to a user's calendar without an end date, it does not show the UI denoting that the event has already been added and allows the user to add the event again. 