### PR TITLE
Add Title To Alert After Adding Event To Calendar Using .action Alert Type Instead

### DIFF
--- a/berkeley-mobile/Events/EventDataSource/EventsViewModel.swift
+++ b/berkeley-mobile/Events/EventDataSource/EventsViewModel.swift
@@ -49,7 +49,7 @@ class EventsViewModel: ObservableObject {
         Task { @MainActor in
             do {
                 try await BMEventManager.shared.addEventToCalendar(calendarEvent: event)
-                presentAlertWithoutAnimation(BMAlert(title: "Event Added To Calendar", message: "View in your Calendar?", type: .action) {
+                presentAlertWithoutAnimation(BMAlert(title: "Event Added To Calendar", message: "Would you like to open this event in Calendar?", type: .action) {
                     let interval = event.startDate.timeIntervalSinceReferenceDate
                     let url = URL(string: "calshow:\(interval)")!
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/berkeley-mobile/Events/EventDataSource/EventsViewModel.swift
+++ b/berkeley-mobile/Events/EventDataSource/EventsViewModel.swift
@@ -49,7 +49,11 @@ class EventsViewModel: ObservableObject {
         Task { @MainActor in
             do {
                 try await BMEventManager.shared.addEventToCalendar(calendarEvent: event)
-                presentAlertWithoutAnimation(BMAlert(title: "", message: "Successfully added to calendar!", type: .notice))
+                presentAlertWithoutAnimation(BMAlert(title: "Event Added To Calendar!", message: "View in your Calendar?", type: .action) {
+                    let interval = event.startDate.timeIntervalSinceReferenceDate
+                    let url = URL(string: "calshow:\(interval)")!
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                })
             } catch {
                 if let bmError = error as? BMError, bmError == .mayExistedInCalendarAlready {
                     presentAlertWithoutAnimation(BMAlert(title: "Successfully added to calendar!", message: error.localizedDescription, type: .notice))

--- a/berkeley-mobile/Events/EventDataSource/EventsViewModel.swift
+++ b/berkeley-mobile/Events/EventDataSource/EventsViewModel.swift
@@ -49,7 +49,7 @@ class EventsViewModel: ObservableObject {
         Task { @MainActor in
             do {
                 try await BMEventManager.shared.addEventToCalendar(calendarEvent: event)
-                presentAlertWithoutAnimation(BMAlert(title: "Event Added To Calendar!", message: "View in your Calendar?", type: .action) {
+                presentAlertWithoutAnimation(BMAlert(title: "Event Added To Calendar", message: "View in your Calendar?", type: .action) {
                     let interval = event.startDate.timeIntervalSinceReferenceDate
                     let url = URL(string: "calshow:\(interval)")!
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)


### PR DESCRIPTION
Fixes #404

- Added title "Event Added To Calendar!"
- Switched BMAlert type from .notice to .action to allow user to jump straight to calendar after adding event
######
- Consider different button prompts in BMAlert for this context
- Rather than "Yes" or "Cancel", maybe "Open in Calendar" and "Ok" buttons instead