### PR TITLE
Cardify Resources Subsections

### DIFF
--- a/berkeley-mobile/Resources/ResourcesSectionDropdown.swift
+++ b/berkeley-mobile/Resources/ResourcesSectionDropdown.swift
@@ -42,21 +42,21 @@ struct ResourcesSectionDropdown<Content: View>: View {
             }
             .padding(.horizontal, 16)
         }
-        .background(Color(BMColor.cardBackground))
+        .background(Color(BMColor.cellBackground))
     }
     
     var body: some View {
         VStack(alignment: .leading) {
             headerButton
             if isExpanded {
-                Divider()
                 content
                     .padding(.vertical, 8)
+                    .padding(.horizontal, 10)
             }
         }
-        .background(Color(BMColor.cardBackground))
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
+        .background(Color(BMColor.cellBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 20)
     }
 }
 
@@ -75,7 +75,7 @@ struct ResourceItemView: View {
         .orange,
         Color(red: 0.4, green: 0.65, blue: 0.9),   // Light blue
         Color(red: 0.9, green: 0.4, blue: 0.4),    // Coral
-        Color(red: 0.5, green: 0.8, blue: 0.5),    // Mint 
+        Color(red: 0.5, green: 0.8, blue: 0.5),    // Mint
         Color(red: 0.7, green: 0.4, blue: 0.7),    // Violet purple
         Color(red: 0.95, green: 0.6, blue: 0.1)    // Golden
     ]
@@ -96,7 +96,7 @@ struct ResourceItemView: View {
     private var coloredBar: some View {
         Rectangle()
             .fill(colorForResource)
-            .frame(width: 8)  
+            .frame(width: 8)
             .cornerRadius(3)
     }
     

--- a/berkeley-mobile/Resources/ResourcesView.swift
+++ b/berkeley-mobile/Resources/ResourcesView.swift
@@ -78,10 +78,9 @@ struct ResourcePageView: View {
                     .foregroundStyle(.secondary)
             } else {
                 ScrollView {
-                    VStack(spacing: 0) {
+                    VStack(spacing: 10) {
                         ForEach(resourceSections, id: \.self) { resourceSection in
                             if let sectionHeaderText = resourceSection.title {
-                                VStack(spacing: 0) {
                                     ResourcesSectionDropdown(title: sectionHeaderText, accentColor: .orange) {
                                         VStack(spacing: 0) {
                                             ForEach(resourceSection.resources, id: \.id) { resource in
@@ -89,13 +88,9 @@ struct ResourcePageView: View {
                                             }
                                         }
                                     }
-                                }
-                                
-                                Divider()
                             }
                         }
                     }
-                    .padding(.vertical, 8)
                 }
                 .background(Color(BMColor.cardBackground))
             }


### PR DESCRIPTION
We currently separate resources subsections ("Safety", "Financial", and "Physical & Mental Health") under "Wellbeing" via a divider. However, when expanded it can be a bit cluttered with the dividers.

Perhaps a better UI visual would to "cardify" these subgroups so they have a more prominent and distinct visual grouping.