### PR TITLE
Fix GuideDetailView Width Header Bug

### DIFF
--- a/berkeley-mobile/Home/Guides/GuideDetailView.swift
+++ b/berkeley-mobile/Home/Guides/GuideDetailView.swift
@@ -54,7 +54,7 @@ struct GuideDetailRowHeaderView: View {
     var body: some View {
         ZStack {
             BMCachedAsyncImageView(imageURL: place.imageURL, aspectRatio: .fill)
-                .frame(maxWidth: .infinity)
+                .frame(maxWidth: 370)
                 .frame(height: 220)
                 .clipped()
             VStack {


### PR DESCRIPTION
The image's maxWidth property set to `.infinity` makes the section below containing the guide place and action buttons to also stretch beyond the visible width of the card. 

Setting the image's maxWidth to some fixed constant will fix this in the meantime.