### PR TITLE
Zaid/show status dining detail view

### DIFF
--- a/berkeley-mobile/Home/Dining/DiningDetailView.swift
+++ b/berkeley-mobile/Home/Dining/DiningDetailView.swift
@@ -36,6 +36,19 @@ struct DiningDetailView: View {
         }
     }
     
+    private var toolbarOpenClosedStatusView: some View {
+        let isOpen = diningHall.isOpen
+        let indicatorColor = (isOpen ? Color.green : Color.red).opacity(0.8)
+        return HStack(spacing: 8) {
+            Circle()
+                .fill(indicatorColor)
+                .frame(width: 8, height: 8)
+            Text(isOpen ? "Open" : "Closed")
+                .foregroundStyle(Color(BMColor.blackText))
+                .font(Font(BMFont.light(12)))
+        }
+    }
+    
     var body: some View {
         VStack {
             if let allDayString {
@@ -66,9 +79,16 @@ struct DiningDetailView: View {
         .onAppear {
             viewModel.logOpenedDiningDetailViewAnalytics(for: diningHall.name)
         }
-        .navigationTitle(diningHall.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .principal) {
+                VStack(spacing: 4) {
+                    Text(diningHall.name)
+                        .font(.headline)
+                    toolbarOpenClosedStatusView
+                }
+            }
+            
             ToolbarItemGroup(placement: .topBarTrailing) {
                 if diningHall.hasCoordinate {
                     Button(action: {


### PR DESCRIPTION
Shows status of each dining hall with an open/closed status.
<img width="832" height="1198" alt="Image 11-24-25 at 7 50 PM" src="https://github.com/user-attachments/assets/33ac81c1-5ab5-40ff-93c7-a93d24ec1700" />
