### PR TITLE
When Dining Halls View Loading UI Is Centered Instead of At the Top

### DIFF
--- a/berkeley-mobile/Home/Dining/DiningHallsView.swift
+++ b/berkeley-mobile/Home/Dining/DiningHallsView.swift
@@ -17,6 +17,7 @@ struct DiningHallsView: View {
     var body: some View {
         if viewModel.isFetching {
             ProgressView("LOADING")
+            Spacer()
         } else {
             BMHomeSectionListView(sectionType: .dining, items: viewModel.diningHalls, mapViewController: mapViewController) { selectedDiningHall in
                 selectionHandler?(selectedDiningHall as! BMDiningHall)


### PR DESCRIPTION
When loading the dining halls view, the UI is centered instead of aligned to the top. The segmented control should be at the top with the activity indicator.