### PR TITLE
Bug: Guides View Scroll Bar Occludes Content

### DIFF
--- a/berkeley-mobile/Home/Guides/GuidesView.swift
+++ b/berkeley-mobile/Home/Guides/GuidesView.swift
@@ -33,7 +33,7 @@ struct GuidesView: View {
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
             }
-            .listStyle(.plain)
+            .contentMargins(.top, 0)
             .scrollContentBackground(.hidden)
         }
     }

--- a/berkeley-mobile/Home/HomeView.swift
+++ b/berkeley-mobile/Home/HomeView.swift
@@ -49,7 +49,7 @@ struct HomeView: View {
             tabNames: ["Dining", "Fitness", "Study", "Guides"],
             selectedTabIndex: $tabSelectedIndex
         )
-        .padding(EdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0))
+        .padding(.top, 20)
     }
     
     private var homeDrawerContentView: some View {
@@ -57,7 +57,7 @@ struct HomeView: View {
             Group {
                 if homeViewModel.isFetching {
                     ProgressView("LOADING")
-                        .padding()
+                        .padding(.vertical, 20)
                     Spacer()
                 } else {
                     segmentedControlHeader
@@ -86,7 +86,7 @@ struct HomeView: View {
             }
             .navigationBarTitleDisplayMode(.inline)
             .containerBackground(.clear, for: .navigation)
-            .padding()
+            .padding(.horizontal)
             .navigationDestination(for: BMDiningHall.self) { diningHall in
                 DiningDetailView(diningHall: diningHall)
                     .containerBackground(.clear, for: .navigation)


### PR DESCRIPTION
- When scrolling in the Guides view, the scroll bar occludes the some of the content.
- Remove excess padding between content and the home drawer segmented control

https://github.com/user-attachments/assets/a9957cbc-6865-4bc8-9dc9-8f1cab216ca0

