### PR TITLE
Fix Crash When Tapping On A Guide

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -1438,7 +1438,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 11.13;
+				MARKETING_VERSION = 11.13.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.asuc.ASUC;
 				PRODUCT_NAME = Berkeley;
 				SWIFT_VERSION = 5.0;
@@ -1462,7 +1462,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 11.13;
+				MARKETING_VERSION = 11.13.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.asuc.ASUC;
 				PRODUCT_NAME = Berkeley;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/berkeley-mobile/Home/Guides/GuidesView.swift
+++ b/berkeley-mobile/Home/Guides/GuidesView.swift
@@ -26,6 +26,7 @@ struct GuidesView: View {
                     NavigationLink {
                         GuideDetailView(guide: guide)
                             .containerBackground(.clear, for: .navigation)
+                            .environment(viewModel)
                     } label: {
                         GuideRowView(guide: guide)
                     }


### PR DESCRIPTION
- Upon tap of a guide to pop to new GuideDetailView, the app crashes due to a missing environmentObject.
