### PR TITLE
Kojiro/replace class with anyobject

### DIFF
--- a/berkeley-mobile/Drawer/DrawerViewDelegate.swift
+++ b/berkeley-mobile/Drawer/DrawerViewDelegate.swift
@@ -16,7 +16,7 @@ enum DrawerState {
 }
 
 /// Handles all moving of drawers and user gestures related to drawers
-protocol DrawerViewDelegate: class {
+protocol DrawerViewDelegate: AnyObject {
     func handlePanGesture(gesture: UIPanGestureRecognizer)
     func handleDrawerDismissal()
     func moveDrawer(to state: DrawerState, duration: Double?)


### PR DESCRIPTION
Replaced deprecated keyword `class` with `AnyObject` in DrawerViewDelegate.

Issue: https://github.com/asuc-octo/berkeley-mobile-ios/issues/536

