### PR TITLE
[Today Page] Weather Tile Set Up Certificates and Entitlements

### DIFF
--- a/berkeley-mobile/berkeley-mobile.entitlements
+++ b/berkeley-mobile/berkeley-mobile.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.weatherkit</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Do any necessary configuration in App Store Connect and in Xcode to enable WeatherKit usage.