### PR TITLE
Remove oldMapView in SafetyMapView

### DIFF
--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -18,14 +18,12 @@ struct SafetyMapView: View {
     var isPresentingDetailView: Bool
     
     var body: some View {
-        if #available(iOS 17.0, *) {
-            SafetyNewMapView(selectedSafetyLog: $selectedSafetyLog,
-                             isShowingLegend: $isShowingLegend,
-                             drawerViewState: $drawerViewState,
-                             isPresentingDetailView: isPresentingDetailView)
-        } else {
-            oldMapView
-        }
+        SafetyNewMapView(selectedSafetyLog: $selectedSafetyLog,
+                         isShowingLegend: $isShowingLegend,
+                         drawerViewState: $drawerViewState,
+                         isPresentingDetailView: isPresentingDetailView)
+        
+        
     }
     
     private var oldMapView: some View {

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -25,13 +25,6 @@ struct SafetyMapView: View {
         
         
     }
-    
-    private var oldMapView: some View {
-        Map(coordinateRegion: .constant(BMConstants.mapBoundsRegion), showsUserLocation: true, annotationItems: safetyViewModel.filteredSafetyLogs) { safetyLog in
-            MapPin(coordinate: safetyLog.coordinate)
-        }
-        .edgesIgnoringSafeArea(.all)
-    }
 }
 
 

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -44,8 +44,6 @@ struct SafetyNewMapView: View {
     
     private let bounds = MapCameraBounds(centerCoordinateBounds: BMConstants.mapBoundsRegion, maximumDistance: BMConstants.mapMaxZoomDistance)
     
-    //PR Check
-    
     var body: some View {
         if #available(iOS 26.0, *) {
             mapViewWithHUD

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -44,6 +44,8 @@ struct SafetyNewMapView: View {
     
     private let bounds = MapCameraBounds(centerCoordinateBounds: BMConstants.mapBoundsRegion, maximumDistance: BMConstants.mapMaxZoomDistance)
     
+    //PR Check
+    
     var body: some View {
         if #available(iOS 26.0, *) {
             mapViewWithHUD


### PR DESCRIPTION
The minimum deployment target version is 18.0 which we means for new updates we only support devices running 18.0 and above.

In SafetyMapView.swift we are conditionalizing on the operating system version so that for devices running iOS 16.0 and older we show oldMapView and newer devices we show SafetyNewMapView.

We should always show SafetyNewMapView.