### PR TITLE
sort home drawer section item by distance to user

### DIFF
--- a/berkeley-mobile/Home/Home Drawer/BMHomeSectionListView.swift
+++ b/berkeley-mobile/Home/Home Drawer/BMHomeSectionListView.swift
@@ -18,13 +18,19 @@ struct BMHomeSectionListView<Content: View>: View {
     
     var selectionHandler: ((any HomeDrawerSectionRowItemType) -> Void)?
     @ViewBuilder var swipeActionsContent: ((any HomeDrawerSectionRowItemType) -> Content)
+	
+	private var sortedItems: [any HomeDrawerSectionRowItemType] {
+		items.sorted {
+			($0.distanceToUser ?? .infinity) < ($1.distanceToUser ?? .infinity)
+		}
+	}
     
     private var pinnedItems: [any HomeDrawerSectionRowItemType] {
-        return items.filter { homeDrawerPinViewModel.pinnedRowItemIDSet.contains($0.docID) }
+		return sortedItems.filter { homeDrawerPinViewModel.pinnedRowItemIDSet.contains($0.docID) }
     }
     
     private var nonPinnedItems: [any HomeDrawerSectionRowItemType] {
-        return items.filter { !homeDrawerPinViewModel.pinnedRowItemIDSet.contains($0.docID) }
+		return sortedItems.filter { !homeDrawerPinViewModel.pinnedRowItemIDSet.contains($0.docID) }
     }
     
     var body: some View {


### PR DESCRIPTION
Recreated #553 from non-forked repo.

Sorts items in the home drawer section list by proximity to the user's current location.
 
Changes:
- Added `sortedItems` computed property that sorts items by `distanceToUser` in ascending order
- `pinnedItems` and `nonPinnedItems` now reference `sortedItems` instead of `items` directly

Issue: https://github.com/asuc-octo/berkeley-mobile-ios/issues/436