### PR TITLE
Kojiro/today dinings tile

### DIFF
--- a/berkeley-mobile.xcodeproj/project.pbxproj
+++ b/berkeley-mobile.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		E8117D172F5FB8D10047CC89 /* TodayTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8117D1B2F5FB8D10047CC89 /* TodayTileView.swift */; };
 		E8117D182F5FB8D10047CC89 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8117D1C2F5FB8D10047CC89 /* TodayView.swift */; };
 		E8117D362F5FBAEE0047CC89 /* TodayWeatherTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8117D352F5FBAEE0047CC89 /* TodayWeatherTileView.swift */; };
+		E8DD11012F80000000000001 /* TodayDiningTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8DD11012F80000000000002 /* TodayDiningTileView.swift */; };
 		E81767582B9A516200599254 /* MapMarkersDropdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81767572B9A516200599254 /* MapMarkersDropdownView.swift */; };
 		E82E2A532ECD833F00785593 /* FeedbackFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82E2A512ECD833F00785593 /* FeedbackFormView.swift */; };
 		E82E2A552ECD835200785593 /* FeedbackFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82E2A542ECD835200785593 /* FeedbackFormViewModel.swift */; };
@@ -362,6 +363,7 @@
 		E8117D1B2F5FB8D10047CC89 /* TodayTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayTileView.swift; sourceTree = "<group>"; };
 		E8117D1C2F5FB8D10047CC89 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		E8117D352F5FBAEE0047CC89 /* TodayWeatherTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWeatherTileView.swift; sourceTree = "<group>"; };
+		E8DD11012F80000000000002 /* TodayDiningTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayDiningTileView.swift; sourceTree = "<group>"; };
 		E81767572B9A516200599254 /* MapMarkersDropdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapMarkersDropdownView.swift; sourceTree = "<group>"; };
 		E82E2A512ECD833F00785593 /* FeedbackFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackFormView.swift; sourceTree = "<group>"; };
 		E82E2A542ECD835200785593 /* FeedbackFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackFormViewModel.swift; sourceTree = "<group>"; };
@@ -978,10 +980,19 @@
 			path = "Weather Tile";
 			sourceTree = "<group>";
 		};
+		E8DD11012F80000000000003 /* Dining Tile */ = {
+			isa = PBXGroup;
+			children = (
+				E8DD11012F80000000000002 /* TodayDiningTileView.swift */,
+			);
+			path = "Dining Tile";
+			sourceTree = "<group>";
+		};
 		E8B8879A2F67722E002B9632 /* Tiles */ = {
 			isa = PBXGroup;
 			children = (
 				E8B6D49A2F7A160D002719AF /* Weather Tile */,
+				E8DD11012F80000000000003 /* Dining Tile */,
 			);
 			path = Tiles;
 			sourceTree = "<group>";
@@ -1350,6 +1361,7 @@
 				1336A322241D92F700949F32 /* MealType.swift in Sources */,
 				018B982625327358004C3B26 /* ActionButton.swift in Sources */,
 				E8117D362F5FBAEE0047CC89 /* TodayWeatherTileView.swift in Sources */,
+				E8DD11012F80000000000001 /* TodayDiningTileView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/berkeley-mobile/Home/HomeView.swift
+++ b/berkeley-mobile/Home/HomeView.swift
@@ -18,7 +18,6 @@ struct HomeView: View {
 
     @InjectedObject(\.homeViewModel) private var homeViewModel
 
-    @State private var tabSelectedIndex = 0
     @State private var navigationPath = NavigationPath()
     @State private var isPresentingDetailView = false
     @State private var selectedDetent: PresentationDetent = .fraction(0.45)
@@ -51,7 +50,7 @@ struct HomeView: View {
     private var segmentedControlHeader: some View {
         BMSegmentedControlView(
             tabNames: ["Dining", "Fitness", "Study", "Guides"],
-            selectedTabIndex: $tabSelectedIndex
+            selectedTabIndex: $homeViewModel.tabSelectedIndex
         )
         .padding(.top, 20)
     }
@@ -65,7 +64,7 @@ struct HomeView: View {
                     Spacer()
                 } else {
                     segmentedControlHeader
-                    switch tabSelectedIndex {
+                    switch homeViewModel.tabSelectedIndex {
                     case 0:
                         DiningHallsView(mapViewController: mapViewController) { selectedDiningHall in
                             navigationPath.append(selectedDiningHall)

--- a/berkeley-mobile/Home/HomeViewModel.swift
+++ b/berkeley-mobile/Home/HomeViewModel.swift
@@ -49,6 +49,15 @@ class HomeViewModel: ObservableObject {
     func showDining() {
         tabSelectedIndex = 0
         isShowingDrawer = true
+		
+        // Hop a runloop tick so .large lands after
+        // HomeView's .onChange resets to .medium.
+        // Known issue: no-ops on first launch before Home
+        // has been shown — BMDrawerView has no initial-offset
+        // logic on .onAppear.
+        DispatchQueue.main.async { [weak self] in
+            self?.drawerViewState = .large
+        }
     }
     
     func presentDetail(type: AnyClass, item: SearchItem) {

--- a/berkeley-mobile/Home/HomeViewModel.swift
+++ b/berkeley-mobile/Home/HomeViewModel.swift
@@ -40,9 +40,15 @@ class HomeViewModel: ObservableObject {
     @Published var isShowingDrawer = true
     @Published var homeDrawerDetailViewInfo: (type: HomeDrawerViewType, item: SearchItem)? = nil
     @Published var drawerViewState = BMDrawerViewState.medium
+    @Published var tabSelectedIndex: Int = 0
 
     init() {
         fetchHomeSectionsData()
+    }
+
+    func showDining() {
+        tabSelectedIndex = 0
+        isShowingDrawer = true
     }
     
     func presentDetail(type: AnyClass, item: SearchItem) {

--- a/berkeley-mobile/Today/Tiles/Dining Tile/TodayDiningTileView.swift
+++ b/berkeley-mobile/Today/Tiles/Dining Tile/TodayDiningTileView.swift
@@ -16,11 +16,13 @@ struct TodayDiningTileView: View {
     private static let nearestCount = 3
 
     private var nearestHalls: [BMDiningHall] {
-        Array(
-            viewModel.diningHalls
-                .sorted { ($0.distanceToUser ?? .infinity) < ($1.distanceToUser ?? .infinity) }
-                .prefix(Self.nearestCount)
-        )
+        let byDistance = viewModel.diningHalls.sorted {
+            ($0.distanceToUser ?? .infinity) < ($1.distanceToUser ?? .infinity)
+        }
+        // If none of the nearest halls are open, promote open halls to the front.
+        let allClosed = !byDistance.prefix(Self.nearestCount).contains(where: \.isOpen)
+        let ordered = allClosed ? byDistance.sorted { $0.isOpen && !$1.isOpen } : byDistance
+        return Array(ordered.prefix(Self.nearestCount))
     }
 
     private var shouldRedact: Bool {

--- a/berkeley-mobile/Today/Tiles/Dining Tile/TodayDiningTileView.swift
+++ b/berkeley-mobile/Today/Tiles/Dining Tile/TodayDiningTileView.swift
@@ -72,13 +72,15 @@ struct TodayDiningTileView: View {
                 .font(.caption)
                 .fontWeight(.semibold)
                 .lineLimit(1)
-            HStack(spacing: 6) {
+            HStack {
                 OpenClosedStatusView(status: hall.isOpen ? .open : .closed)
+                Spacer()
                 Text("\(hall.distanceToUser ?? 0.0, specifier: "%.1f") mi")
                     .font(Font(BMFont.light(10)))
                     .foregroundStyle(.white.opacity(0.9))
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var placeholderRow: some View {
@@ -86,12 +88,14 @@ struct TodayDiningTileView: View {
             Text("Dining Hall")
                 .font(.caption)
                 .fontWeight(.semibold)
-            HStack(spacing: 6) {
+            HStack {
                 OpenClosedStatusView(status: .open)
+                Spacer()
                 Text("0.0 mi")
                     .font(Font(BMFont.light(10)))
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func navigateToDiningInHome() {

--- a/berkeley-mobile/Today/Tiles/Dining Tile/TodayDiningTileView.swift
+++ b/berkeley-mobile/Today/Tiles/Dining Tile/TodayDiningTileView.swift
@@ -1,0 +1,103 @@
+//
+//  TodayDiningTileView.swift
+//  berkeley-mobile
+//
+//  Copyright © 2026 ASUC OCTO. All rights reserved.
+//
+
+import FactoryKit
+import SwiftUI
+import UIKit
+
+struct TodayDiningTileView: View {
+    @InjectedObservable(\.diningHallsViewModel) private var viewModel
+    @InjectedObject(\.homeViewModel) private var homeViewModel
+
+    private static let nearestCount = 3
+
+    private var nearestHalls: [BMDiningHall] {
+        Array(
+            viewModel.diningHalls
+                .sorted { ($0.distanceToUser ?? .infinity) < ($1.distanceToUser ?? .infinity) }
+                .prefix(Self.nearestCount)
+        )
+    }
+
+    private var shouldRedact: Bool {
+        viewModel.diningHalls.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+
+            VStack(alignment: .leading, spacing: 6) {
+                if shouldRedact {
+                    ForEach(0..<Self.nearestCount, id: \.self) { _ in
+                        placeholderRow
+                    }
+                } else {
+                    ForEach(nearestHalls, id: \.docID) { hall in
+                        diningRow(for: hall)
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(.white)
+        .redacted(reason: shouldRedact ? .placeholder : [])
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .contentShape(Rectangle())
+        .onTapGesture { navigateToDiningInHome() }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Dining")
+                .font(.headline)
+                .fontWeight(.semibold)
+            Spacer()
+            Image(systemName: "fork.knife")
+                .font(.callout)
+        }
+    }
+
+    @ViewBuilder
+    private func diningRow(for hall: BMDiningHall) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(hall.name)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+            HStack(spacing: 6) {
+                OpenClosedStatusView(status: hall.isOpen ? .open : .closed)
+                Text("\(hall.distanceToUser ?? 0.0, specifier: "%.1f") mi")
+                    .font(Font(BMFont.light(10)))
+                    .foregroundStyle(.white.opacity(0.9))
+            }
+        }
+    }
+
+    private var placeholderRow: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Dining Hall")
+                .font(.caption)
+                .fontWeight(.semibold)
+            HStack(spacing: 6) {
+                OpenClosedStatusView(status: .open)
+                Text("0.0 mi")
+                    .font(Font(BMFont.light(10)))
+            }
+        }
+    }
+
+    private func navigateToDiningInHome() {
+        homeViewModel.showDining()
+
+        let sceneDelegate = UIApplication.shared.connectedScenes
+            .first?.delegate as? SceneDelegate
+        let tabBarController = sceneDelegate?.window?.rootViewController as? TabBarController
+        tabBarController?.selectedIndex = 1
+    }
+}

--- a/berkeley-mobile/Today/TodayTileAttributes.swift
+++ b/berkeley-mobile/Today/TodayTileAttributes.swift
@@ -67,11 +67,15 @@ struct TodayTileStyle {
 
 enum TodayTiles: CaseIterable {
     case weather
+    case dining
 
+    @ViewBuilder
     func view() -> some View {
         switch self {
         case .weather:
-            return TodayWeatherTileView()
+            TodayWeatherTileView()
+        case .dining:
+            TodayDiningTileView()
         }
     }
 
@@ -84,6 +88,14 @@ enum TodayTiles: CaseIterable {
                 styles: [TodayTileStyle.Name.defaultName: TodayTileStyle(colors: [
                     Color(red: 0.20, green: 0.52, blue: 0.87),
                     Color(red: 0.50, green: 0.80, blue: 0.99)])]
+            )
+        case .dining:
+            TodayTileAttributes(
+                span: .halfWidth,
+                displayedStyleName: displayedStyleName,
+                styles: [TodayTileStyle.Name.defaultName: TodayTileStyle(colors: [
+                    Color(red: 0.95, green: 0.45, blue: 0.20),
+                    Color(red: 0.99, green: 0.70, blue: 0.35)])]
             )
         }
     }


### PR DESCRIPTION
### Summary
- Adds a "Nearest Dining Halls" tile to the Today view showing the 3 closest halls with open/closed status and distance.
- Tapping the tile switches to the Home tab, opens the drawer to `.large`, and selects the Dining segment.
- Lifts `HomeView`'s segment index into `HomeViewModel` so it can be driven externally.

Issue: #524 

### demo
https://github.com/user-attachments/assets/fd8ad2b6-c04c-40d7-adc1-005330b39267