### PR TITLE
Add search bar UI to Resources tab

### DIFF
--- a/berkeley-mobile/Resources/ResourcesView.swift
+++ b/berkeley-mobile/Resources/ResourcesView.swift
@@ -11,6 +11,28 @@ import SwiftUI
 struct ResourcesView: View {
     @StateObject private var resourcesViewModel = ResourcesViewModel()
     @State private var tabSelectedValue = 0
+    @State private var searchText = ""
+    
+    var isSearching: Bool {
+        !searchText.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var searchResults: [(categoryName: String, section: BMResourceSection)] {
+        let query = searchText.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return [] }
+ 
+        return resourcesViewModel.resourceCategories.flatMap { category in
+            category.sections.filter { section in
+                let titleMatch = section.title?.localizedCaseInsensitiveContains(query) ?? false
+                let resourceMatch = section.resources.contains {
+                    $0.name.localizedCaseInsensitiveContains(query)
+                }
+                return titleMatch || resourceMatch
+            }
+            .map { (categoryName: category.name, section: $0) }
+        }
+    }
+
     
     init() {
         // Use this if NavigationBarTitle is with Large Font
@@ -49,8 +71,59 @@ struct ResourcesView: View {
             }
             .background(Color(BMColor.cardBackground))
             .presentAlert(alert: $resourcesViewModel.alert)
+            .searchable(
+                text: $searchText,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "Search resources..."
+            )
+            .animation(.default, value: isSearching)
+
         }
     }
+    
+    // MARK: - Search Results View
+ 
+    @ViewBuilder
+    private var searchResultsView: some View {
+        if searchResults.isEmpty {
+            BMContentUnavailableView(
+                iconName: "magnifyingglass",
+                title: "No Results",
+                subtitle: "No resources found for \"\(searchText.trimmingCharacters(in: .whitespaces))\""
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .transition(.opacity)
+        } else {
+            ScrollView {
+                VStack(spacing: 10) {
+                    ForEach(searchResults, id: \.section) { result in
+                        if let sectionTitle = result.section.title {
+                            VStack(alignment: .leading, spacing: 4) {
+                                // Category label above each matched section
+                                Text(result.categoryName)
+                                    .font(Font(BMFont.regular(12)))
+                                    .foregroundStyle(.secondary)
+                                    .padding(.horizontal)
+ 
+                                ResourcesSectionDropdown(title: sectionTitle, accentColor: .orange) {
+                                    VStack(spacing: 0) {
+                                        ForEach(result.section.resources, id: \.id) { resource in
+                                            ResourceItemView(resource: resource)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.top, 8)
+            }
+            .background(Color(BMColor.cardBackground))
+            .transition(.opacity)
+        }
+    }
+
+    // MARK: - Empty State
     
     private var noResourcesAvailableView: some View {
         BMContentUnavailableView(

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -18,14 +18,12 @@ struct SafetyMapView: View {
     var isPresentingDetailView: Bool
     
     var body: some View {
-        if #available(iOS 17.0, *) {
-            SafetyNewMapView(selectedSafetyLog: $selectedSafetyLog,
-                             isShowingLegend: $isShowingLegend,
-                             drawerViewState: $drawerViewState,
-                             isPresentingDetailView: isPresentingDetailView)
-        } else {
-            oldMapView
-        }
+        SafetyNewMapView(selectedSafetyLog: $selectedSafetyLog,
+                         isShowingLegend: $isShowingLegend,
+                         drawerViewState: $drawerViewState,
+                         isPresentingDetailView: isPresentingDetailView)
+        
+        
     }
     
     private var oldMapView: some View {

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -25,13 +25,6 @@ struct SafetyMapView: View {
         
         
     }
-    
-    private var oldMapView: some View {
-        Map(coordinateRegion: .constant(BMConstants.mapBoundsRegion), showsUserLocation: true, annotationItems: safetyViewModel.filteredSafetyLogs) { safetyLog in
-            MapPin(coordinate: safetyLog.coordinate)
-        }
-        .edgesIgnoringSafeArea(.all)
-    }
 }
 
 

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -44,8 +44,6 @@ struct SafetyNewMapView: View {
     
     private let bounds = MapCameraBounds(centerCoordinateBounds: BMConstants.mapBoundsRegion, maximumDistance: BMConstants.mapMaxZoomDistance)
     
-    //PR Check
-    
     var body: some View {
         if #available(iOS 26.0, *) {
             mapViewWithHUD

--- a/berkeley-mobile/Safety/SafetyMapView.swift
+++ b/berkeley-mobile/Safety/SafetyMapView.swift
@@ -44,6 +44,8 @@ struct SafetyNewMapView: View {
     
     private let bounds = MapCameraBounds(centerCoordinateBounds: BMConstants.mapBoundsRegion, maximumDistance: BMConstants.mapMaxZoomDistance)
     
+    //PR Check
+    
     var body: some View {
         if #available(iOS 26.0, *) {
             mapViewWithHUD


### PR DESCRIPTION
The resources tab contains different links grouped into subgroups within three categories: "Wellbeing", "Campus Life", and "Academics".

To help users better find links, we would like to add a search bar that not only show results based on matching the exact text but also intelligently surface results based on a natural language search query.

For example, "What activities can I do around campus?" and it can suggest the "Events and Attractions" subgroup under "Campus Life". This cannot be done through regular string text matching and requires natural language understanding.

We will first start with a basic search query functionality based on matching text, then implement natural language results through an on-device LLM (Apple's Foundational Models). feature #528 